### PR TITLE
[CHORE] increase build resources

### DIFF
--- a/openshift/client.bc.yml
+++ b/openshift/client.bc.yml
@@ -58,6 +58,9 @@ objects:
           kind: ImageStreamTag
           name: ${APP_NAME}-client:${IMAGE_TAG}
       resources:
-        limits:
+        requests:
           cpu: '500m'
           memory: 2Gi
+        limits:
+          cpu: '750m'
+          memory: 3Gi

--- a/openshift/server.bc.yml
+++ b/openshift/server.bc.yml
@@ -59,6 +59,9 @@ objects:
           kind: ImageStreamTag
           name: ${APP_NAME}-server:${IMAGE_TAG}
       resources:
+        requests:
+          cpu: '500m'
+          memory: 2Gi
         limits:
-          cpu: '300m'
-          memory: 1Gi
+          cpu: '750m'
+          memory: 3Gi


### PR DESCRIPTION
[TC-3](https://bcdevex.atlassian.net/browse/TC-3)

Objective:
This is the current quota for builds:
<img width="1085" alt="Screenshot 2024-01-09 at 3 43 45 PM" src="https://github.com/bcgov/talent-cloud/assets/61991654/062d236b-4b5c-4d1e-9a9d-e52c83085a5d">

I think this is okay since the builds do not run concurrently, we can make this request appropriately.

[TC-3]: https://bcdevex.atlassian.net/browse/TC-3?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ