### PR TITLE
[TC-372] get and display different experiences

### DIFF
--- a/backend/src/database/entities/personnel-function-experience.entity.ts
+++ b/backend/src/database/entities/personnel-function-experience.entity.ts
@@ -31,6 +31,7 @@ export class ExperienceEntity {
 
   toResponseObject(): ExperienceRO {
     return {
+      id: this.functionId,
       functionName: this.function.name,
       functionAbbrv: this.function.abbreviation,
       experienceType: this.experienceType,

--- a/backend/src/personnel/personnel.service.ts
+++ b/backend/src/personnel/personnel.service.ts
@@ -187,7 +187,6 @@ export class PersonnelService {
     id: string,
   ): Promise<Record<string, PersonnelRO>> {
     const person = await this.personnelRepository.findOne({ where: { id }, relations: ['experiences', 'experiences.function'] });
-    console.log(person);
 
     return person.toResponseObject(role);
   }

--- a/backend/src/personnel/personnel.service.ts
+++ b/backend/src/personnel/personnel.service.ts
@@ -186,7 +186,8 @@ export class PersonnelService {
     role: Role,
     id: string,
   ): Promise<Record<string, PersonnelRO>> {
-    const person = await this.personnelRepository.findOneBy({ id: id });
+    const person = await this.personnelRepository.findOne({ where: { id }, relations: ['experiences', 'experiences.function'] });
+    console.log(person);
 
     return person.toResponseObject(role);
   }

--- a/backend/src/personnel/ro/experience.ro.ts
+++ b/backend/src/personnel/ro/experience.ro.ts
@@ -3,6 +3,13 @@ import { Experience } from "../../common/enums";
 
 export class ExperienceRO {
   @ApiProperty({
+    description: 'Id of function',
+    required: true,
+    example: '1',
+  })
+  id: number;
+
+  @ApiProperty({
     description: 'Name of function',
     required: true,
     example: 'Operations',

--- a/frontend/src/hooks/useFunctions.tsx
+++ b/frontend/src/hooks/useFunctions.tsx
@@ -1,0 +1,20 @@
+import type { FunctionType } from '@/pages/dashboard';
+import { AxiosPrivate } from '@/utils';
+import { useEffect, useState } from 'react';
+
+const useFunctions = () => {
+  const [functions, setFunctions] = useState<FunctionType[]>([]);
+
+  useEffect(() => {
+    (async () => {
+      const { data } = await AxiosPrivate.get('/function');
+      setFunctions(data);
+    })();
+  }, []);
+
+  return {
+    functions,
+  };
+};
+
+export default useFunctions;

--- a/frontend/src/pages/dashboard/constants.ts
+++ b/frontend/src/pages/dashboard/constants.ts
@@ -51,6 +51,7 @@ export interface Location {
 export interface ExperienceInterface {
   experienceType: Experience;
   functionName: string;
+  id: number;
 }
 export interface AvailabilityInterface {
   availabilityType: AvailabilityType;

--- a/frontend/src/pages/profile/Profile.tsx
+++ b/frontend/src/pages/profile/Profile.tsx
@@ -11,6 +11,7 @@ import {
 import { ChevronLeftIcon } from '@heroicons/react/24/solid';
 import { useParams } from 'react-router-dom';
 import usePersonnel from '@/hooks/usePersonnel';
+import useFunctions from '@/hooks/useFunctions';
 import useAvailability from '@/hooks/useAvailability';
 import ProfileDetails from './ProfileDetails';
 import ProfileHeader from './ProfileHeader';
@@ -20,6 +21,7 @@ import SchedulerPopUp from './SchedulerPopUp';
 import type { AvailabilityRange } from '../dashboard';
 import { ProfileEditForm } from './ProfileEditForm';
 import type { AvailabilityType } from '@/common';
+import ProfileFunctions from './ProfileFunctions';
 
 const Profile = () => {
   const { personnelId } = useParams() as { personnelId: string };
@@ -27,6 +29,7 @@ const Profile = () => {
   const { availability, getAvailability, saveAvailability } = useAvailability({
     personnelId,
   });
+  const { functions } = useFunctions();
 
   const { role } = useRole();
   const [availabilityQuery, setAvailabilityQuery] = useState<{
@@ -115,6 +118,7 @@ const Profile = () => {
               handleOpenEditPopUp={handleOpenEditPopUp}
               updatePersonnel={updatePersonnel}
             />
+            <ProfileFunctions functions={functions} personnel={personnel} />
             <Scheduler
               name={personnel.firstName}
               availability={availability}

--- a/frontend/src/pages/profile/ProfileFunctions.tsx
+++ b/frontend/src/pages/profile/ProfileFunctions.tsx
@@ -1,0 +1,114 @@
+import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/24/solid';
+import {
+  Accordion,
+  AccordionBody,
+  AccordionHeader,
+  Chip,
+} from '@material-tailwind/react';
+import { useState } from 'react';
+import type { FunctionType, Personnel } from '../dashboard';
+import { Experience } from '@/common';
+
+const ProfileFunctions = ({
+  functions,
+  personnel,
+}: {
+  functions: FunctionType[];
+  personnel: Personnel;
+}) => {
+  const [open, setOpen] = useState(1);
+  const handleOpen = (value: number) => setOpen(open === value ? 0 : value);
+
+  const renderExperienceLevel = (experience: Experience | undefined) => {
+    switch (experience) {
+      case Experience.CHIEF_EXPERIENCED:
+        return (
+          <Chip
+            className="text-purple bg-purple border-darkPurple border-2 rounded-md font-bold capitalize py-0"
+            value="Chief Experience"
+          />
+        );
+      case Experience.EXPERIENCED:
+        return (
+          <Chip
+            className="text-info bg-infoBannerLight border-infoDark border-2 rounded-md font-bold capitalize py-0"
+            value="Experienced"
+          />
+        );
+      case Experience.OUTSIDE_EXPERIENCED:
+        return (
+          <Chip
+            className="text-yellow bg-yellow border-darkYellow border-2 rounded-md font-bold capitalize py-0"
+            value="Outside Experience"
+          />
+        );
+      // f9f2f6 826521
+      case Experience.INTERESTED:
+        return (
+          <Chip
+            className="text-successDark bg-successBannerLight border-successDark rounded-md border-2 font-bold capitalize py-0"
+            value="Interested"
+          />
+        );
+      default:
+        return <span>-</span>;
+    }
+  };
+
+  return (
+    <section className="bg-white">
+      <div className="pt-6 px-10">
+        <Accordion
+          className="border-2 border-slate-950"
+          placeholder={'Schedule'}
+          open={open === 1}
+          icon={
+            open ? (
+              <ChevronUpIcon className="h-8 w-5 fill-[#606060]" />
+            ) : (
+              <ChevronDownIcon className="h-8 w-5 fill-[#606060]" />
+            )
+          }
+        >
+          <AccordionHeader
+            placeholder={'Schedule'}
+            onClick={() => handleOpen(1)}
+            className="bg-grayBackground px-8"
+          >
+            Function & Experience Levels
+          </AccordionHeader>
+          <AccordionBody className="px-8">
+            <div className="">
+              <div className="flex flex-row border-b-2 border-slate-800 py-2">
+                <div className="basis-1/2">
+                  <span className="text-info font-bold">Function</span>
+                </div>
+                <div className="basis-1/2">
+                  <span className="text-info font-bold">Experience Level</span>
+                </div>
+              </div>
+              {functions.map((f) => (
+                <div
+                  key={f.id}
+                  className="flex flex-row border-b-2 border-gray-100 py-2 items-center"
+                >
+                  <div className="basis-1/2">
+                    <span>{f.name}</span>
+                  </div>
+                  <div>
+                    {renderExperienceLevel(
+                      personnel.experiences?.find((e) => e.id === f.id)
+                        ?.experienceType,
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </AccordionBody>
+        </Accordion>
+      </div>
+    </section>
+  );
+};
+
+export default ProfileFunctions;

--- a/frontend/src/pages/profile/ProfileFunctions.tsx
+++ b/frontend/src/pages/profile/ProfileFunctions.tsx
@@ -42,7 +42,6 @@ const ProfileFunctions = ({
             value="Outside Experience"
           />
         );
-      // f9f2f6 826521
       case Experience.INTERESTED:
         return (
           <Chip

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -62,6 +62,8 @@ module.exports = withMT({
         calBlue: '#ecf5fa',
         calBlueTwo: '#1a5b97',
         calBlueHover: '#d8eaf5',
+        darkPurple: '#6f2fa2',
+        darkYellow: '#826521',
       },
       backgroundColor: {
         backgroundBlue: '#003366',
@@ -78,9 +80,10 @@ module.exports = withMT({
         successBannerLight: '#DFF0D8',
         warningBannerDark: '#6C4A00',
         warningBannerLight: '#F9F1C6',
-        
         infoBannerDark: '#1A5A96',
         infoBannerLight: '#D9EAF7',
+        purple: '#e8d9f7',
+        yellow: '#f9f2c6',
       },
       textColor: {
         info: '#1a5a96',
@@ -92,7 +95,9 @@ module.exports = withMT({
         black: '#000000',
         ministry: '#1A5A96',
         error: '#A12622', 
-        warning: '#6C4A00'
+        warning: '#6C4A00',
+        purple: '#6f2fa2',
+        yellow: '#826521',
       },
     },
   },


### PR DESCRIPTION
[TC-372](https://bcdevex.atlassian.net/browse/TC-372)

Objective:
Display functions / experience levels in profile page
Designs from [Figma Prototype](https://www.figma.com/proto/EsuYOEyGPvIVDEFGnYCJ2f/CoCo-EMCR%3A-TEAMS-Redesign?page-id=2349%3A12933&type=design&node-id=2358-47218&viewport=-237%2C-1598%2C0.2&t=kxYM1ZJE08ZzOdWh-1&scaling=scale-down&starting-point-node-id=2358%3A47218)

<img width="1025" alt="Screenshot 2024-03-06 at 12 40 36 AM" src="https://github.com/bcgov/talent-cloud/assets/61991654/7ba75658-bad8-4d31-99e1-9a3200c04179">


[TC-372]: https://bcdevex.atlassian.net/browse/TC-372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ