### PR TITLE
[TC-364] fill in empty date for "today"

### DIFF
--- a/backend/src/personnel/personnel.service.ts
+++ b/backend/src/personnel/personnel.service.ts
@@ -85,7 +85,6 @@ export class PersonnelService {
 
     qb.leftJoinAndSelect('personnel.experiences', 'experiences');
     qb.leftJoinAndSelect('experiences.function', 'function');
-    qb.leftJoinAndSelect('personnel.availability', 'availability');
     qb.leftJoinAndSelect('personnel.workLocation', 'location');
 
     if (query.name) {
@@ -136,6 +135,7 @@ export class PersonnelService {
      */
 
     if (query.availabilityType) {
+      qb.leftJoinAndSelect('personnel.availability', 'availability');
       qb.andWhere('availability.availabilityType = :availabilityType', {
         availabilityType: query.availabilityType,
       });
@@ -154,19 +154,7 @@ export class PersonnelService {
         });
       }
     } else {
-      /**
-       * If no availability type is provided, we will default to today's date and return all statuses
-       */
-      qb.andWhere(
-        new Brackets((qb) => {
-          qb.where('availability.date = :date', {
-            date: datePST(new Date()),
-          }).orWhere(
-            'personnel.id not in (select p.id from availability a join personnel p on p.id=a.personnel where date=:date)',
-            { date: datePST(new Date()) },
-          );
-        }),
-      );
+      qb.leftJoinAndSelect('personnel.availability', 'availability', 'availability.date = :date', { date: datePST(new Date()) });
     }
 
     if (query.showInactive) {


### PR DESCRIPTION
[TC-364](https://bcdevex.atlassian.net/browse/TC-364)

Objective:
This isn't 100% related to TC-364, just that it was the reason it was sent back.
Basically, for personnel that do not have a date for today, it was still pulling in a lot of their dates, and it wasn't necessarily reflective of their NOT_INDICATED status.
The change here is to make it so that personnel.availability is rightly empty, and then backfilled later if it is empty. This might have repercussions in the future if we're pulling a single entity, so we may later want to move this logic to the GET() endpoint itself, or figure out another way.

[TC-364]: https://bcdevex.atlassian.net/browse/TC-364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ