### PR TITLE
[FIX] fixed path rewrite for api requests from FE to BE

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -69,6 +69,7 @@ export default defineConfig({
     proxy: {
       // Proxy API requests to the backend
       '/api': {
+        rewrite: (path) => path.replace(/^\/api\/\v1/, ''),
         target: process.env.BACKEND_URL,
         changeOrigin: true,
       },


### PR DESCRIPTION
[FIX](https://bcdevex.atlassian.net/browse/FIX)

Objective:

- <hostname>/api/v1 should point to the swagger docs if visited in the browser
- updated vite config to route /api/v1 to this^^ url