### PR TITLE
[TC-643] use from date in the absence of to date for search filters

### DIFF
--- a/frontend/src/hooks/useFilters.tsx
+++ b/frontend/src/hooks/useFilters.tsx
@@ -31,14 +31,16 @@ export const useFilters = () => {
 
   const handleSetDates = (range: DateRange | undefined) => {
     setAvailabilityDates(range);
-    if (!range) {
+    if (!range || !range.from) {
       clearSearchParams('availabilityFromDate');
       clearSearchParams('availabilityToDate');
     } else {
       setSearchUrlParams((prev: URLSearchParams) => ({
         ...Object.fromEntries([...prev]),
         ['availabilityFromDate']: range.from ? datePST(range.from, true) : undefined,
-        ['availabilityToDate']: range?.to ? datePST(range.to, true) : undefined,
+        ['availabilityToDate']: range?.to
+          ? datePST(range.to, true)
+          : datePST(range.from, true),
       }));
     }
   };


### PR DESCRIPTION
[TC-643](https://bcdevex.atlassian.net/browse/TC-643)

Objective:
This feels like the right solution, since:
1. The library we're using seems impossible to get a `to` date without a `from` date and
2. On the backend, we only add the FROM and TO to the query if both are present

[TC-643]: https://bcdevex.atlassian.net/browse/TC-643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ