### PR TITLE
[TC-693] remove coordinator notes for logistics officers

### DIFF
--- a/backend/src/personnel/personnel.service.ts
+++ b/backend/src/personnel/personnel.service.ts
@@ -606,7 +606,11 @@ export class PersonnelService {
     const lastDeployed = await this.getLastDeployedDate(id);
     const personnel = person.toResponseObject(role, lastDeployed);
 
-    return personnel
+    if (role === Role.LOGISTICS) {
+      delete personnel.coordinatorNotes;
+    }
+
+    return personnel;
   }
 
   /**
@@ -625,7 +629,11 @@ export class PersonnelService {
 
     const lastDeployed = await this.getLastDeployedDate(id);
 
-    return person.toResponseObject(role, lastDeployed);
+    const personnel = person.toResponseObject(role, lastDeployed);
+    if (role === Role.LOGISTICS) {
+      delete personnel.coordinatorNotes;
+    }
+    return personnel;
   }
 
   /**


### PR DESCRIPTION
[TC-693](https://bcdevex.atlassian.net/browse/TC-693)

Objective:
This could be done better if we were to properly return things as ROs in the `toResponseObject`. It could be cleaned up there. But this should suffice for now

[TC-693]: https://bcdevex.atlassian.net/browse/TC-693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ