### PR TITLE
[TC-688] removing default when Update Availability clicked

### DIFF
--- a/frontend/src/pages/profile/SchedulerPopUp.tsx
+++ b/frontend/src/pages/profile/SchedulerPopUp.tsx
@@ -32,8 +32,8 @@ const SchedulerPopUp = ({
   onSave: (dates: AvailabilityRange) => void;
 }) => {
   const [range, setRange] = useState<DateRange | undefined>({
-    from: editedFrom ? offsetTimezoneDate(editedFrom) : new Date(),
-    to: editedTo ? offsetTimezoneDate(editedTo) : new Date(),
+    from: editedFrom ? offsetTimezoneDate(editedFrom) : undefined,
+    to: editedTo ? offsetTimezoneDate(editedTo) : undefined,
   });
   const [selectedStatus, setSelectedStatus] = useState<AvailabilityType>(
     editedAvailabilityType ?? AvailabilityType.AVAILABLE,


### PR DESCRIPTION
[TC-688](https://bcdevex.atlassian.net/browse/TC-688)

Objective:
By removing the default, the user should be less confused when they do the first click on the calendar; the first click should always reflect the date they intend to start in.

[TC-688]: https://bcdevex.atlassian.net/browse/TC-688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ