### PR TITLE
[FIX] only set cls in guards

### DIFF
--- a/backend/src/audit/audit.service.ts
+++ b/backend/src/audit/audit.service.ts
@@ -22,7 +22,7 @@ export class AuditService {
     const updatedBy =
       this.clsService.get('primaryRole') === Role.MEMBER
         ? 'member'
-        : this.clsService.get('email');
+        : this.clsService.get('email') || 'SYSTEM';
     await this.auditRepository.save({
       data: {
         before,

--- a/backend/src/audit/subscribers/bcws-personnel.subscriber.ts
+++ b/backend/src/audit/subscribers/bcws-personnel.subscriber.ts
@@ -26,10 +26,6 @@ export class BcwsPersonnelSubscriber
   }
 
   afterInsert(event: InsertEvent<BcwsPersonnelEntity>) {
-    if (!this.clsService.get('primaryRole')) {
-      // Typically, insertion of personnel would be from the CHEFS form, hence SYSTEM
-      this.clsService.set('email', 'SYSTEM');
-    }
     this.auditService.logAudit(
       'NULL',
       JSON.stringify(event.entity),
@@ -39,10 +35,6 @@ export class BcwsPersonnelSubscriber
   }
 
   afterUpdate(event: UpdateEvent<BcwsPersonnelEntity>): void {
-    if (!this.clsService.get('primaryRole')) {
-      // This could happen in automated jobs from the system
-      this.clsService.set('email', 'SYSTEM');
-    }
     this.auditService.logAudit(
       JSON.stringify(event.databaseEntity),
       JSON.stringify(event.entity),

--- a/backend/src/audit/subscribers/emcr-personnel.subscriber.ts
+++ b/backend/src/audit/subscribers/emcr-personnel.subscriber.ts
@@ -26,10 +26,6 @@ export class EmcrPersonnelSubscriber
   }
 
   afterInsert(event: InsertEvent<EmcrPersonnelEntity>) {
-    if (!this.clsService.get('primaryRole')) {
-      // Typically, insertion of personnel would be from the CHEFS form, hence SYSTEM
-      this.clsService.set('email', 'SYSTEM');
-    }
     this.auditService.logAudit(
       'NULL',
       JSON.stringify(event.entity),
@@ -39,10 +35,6 @@ export class EmcrPersonnelSubscriber
   }
 
   afterUpdate(event: UpdateEvent<EmcrPersonnelEntity>): void {
-    if (!this.clsService.get('primaryRole')) {
-      // This could happen in automated jobs from the system
-      this.clsService.set('email', 'SYSTEM');
-    }
     this.auditService.logAudit(
       JSON.stringify(event.databaseEntity),
       JSON.stringify(event.entity),

--- a/backend/src/audit/subscribers/personnel.subscriber.ts
+++ b/backend/src/audit/subscribers/personnel.subscriber.ts
@@ -28,10 +28,6 @@ export class PersonnelSubscriber
   }
 
   afterInsert(event: InsertEvent<PersonnelEntity>) {
-    if (!this.clsService.get('primaryRole')) {
-      // Typically, insertion of personnel would be from the CHEFS form, hence SYSTEM
-      this.clsService.set('email', 'SYSTEM');
-    }
     this.auditService.logAudit(
       'NULL',
       JSON.stringify(event.entity),
@@ -47,10 +43,6 @@ export class PersonnelSubscriber
   afterUpdate(event: UpdateEvent<PersonnelEntity>): void {
     delete event.entity.bcws;
     delete event.entity.emcr;
-    if (!this.clsService.get('primaryRole')) {
-      // This could happen in automated jobs from the system
-      this.clsService.set('email', 'SYSTEM');
-    }
     this.auditService.logAudit(
       JSON.stringify(event.databaseEntity),
       JSON.stringify(event.entity),

--- a/backend/src/audit/subscribers/recommitment.subscriber.ts
+++ b/backend/src/audit/subscribers/recommitment.subscriber.ts
@@ -26,10 +26,6 @@ export class RecommitmentSubscriber
 
   afterUpdate(event: UpdateEvent<RecommitmentEntity>): void {
     delete event.entity.personnel;
-    if (!this.clsService.get('primaryRole')) {
-      // This could happen in automated jobs from the system
-      this.clsService.set('email', 'SYSTEM');
-    }
 
     // No database entity here?
     this.auditService.logAudit(


### PR DESCRIPTION
clsService.set isn't working from jobs correctly, so we ensure we only use it when we are in the application lifecycle itself, not in jobs

Objective:
