### PR TITLE
[TC-962] reactivation email template

### DIFF
--- a/backend/src/recommitment/recommitment.service.ts
+++ b/backend/src/recommitment/recommitment.service.ts
@@ -287,7 +287,7 @@ export class RecommitmentService {
       case RecommitmentStatus.PENDING:
         return {
           templateType: EmailTags.MEMBER_REACTIVATE,
-          templateRecipient: TemplateType.SUPERVISOR,
+          templateRecipient: TemplateType.MEMBER,
         };
       case RecommitmentStatus.MEMBER_COMMITTED:
         return {

--- a/backend/src/recommitment/recommitment.service.ts
+++ b/backend/src/recommitment/recommitment.service.ts
@@ -249,6 +249,7 @@ export class RecommitmentService {
 
     const dayAfterEndDate = addDays(recommitmentCycle.endDate, 1);
     const currentPST = datePST(new Date());
+    // If reinitiation end date exists and current date is between end date & reinit end date, use reinit end date
     const endDate = 
       isAfter(currentPST, dayAfterEndDate) &&
       isAfter(currentPST, recommitmentCycle.startDate) &&

--- a/backend/src/recommitment/recommitment.service.ts
+++ b/backend/src/recommitment/recommitment.service.ts
@@ -18,6 +18,8 @@ import { PersonnelRecommitmentDTO } from '../personnel/dto/recommitment/create-p
 import { ProgramRecommitmentDTO } from '../personnel/dto/recommitment/update-personnel-recommitment.dto';
 import { PersonnelService } from '../personnel/personnel.service';
 import { RecommitmentRO } from '../personnel/ro/recommitment.ro';
+import { addDays, isAfter } from 'date-fns';
+import { datePST } from '../common/helpers';
 
 @Injectable()
 export class RecommitmentService {
@@ -240,15 +242,26 @@ export class RecommitmentService {
       relations: ['personnel'],
     });
     const recommitmentCycle = await this.checkRecommitmentPeriod();
+    
     const { templateType, templateRecipient } = this.getEmailTemplate(
       recommitmentUpdate.status,
     );
+
+    const dayAfterEndDate = addDays(recommitmentCycle.endDate, 1);
+    const currentPST = datePST(new Date());
+    const endDate = 
+      isAfter(currentPST, dayAfterEndDate) &&
+      isAfter(currentPST, recommitmentCycle.startDate) &&
+      recommitmentCycle.reinitiationEndDate ?
+      recommitmentCycle.reinitiationEndDate :
+      recommitmentCycle.endDate;
+
 
     const emailTemplate = this.mailService.generateTemplate(
       templateType,
       templateRecipient,
       [personnel.toResponseObject()],
-      recommitmentCycle.endDate,
+      endDate,
       recommitmentUpdate.program,
     );
 
@@ -270,6 +283,11 @@ export class RecommitmentService {
     templateRecipient: TemplateType;
   } {
     switch (status) {
+      case RecommitmentStatus.PENDING:
+        return {
+          templateType: EmailTags.MEMBER_REACTIVATE,
+          templateRecipient: TemplateType.SUPERVISOR,
+        };
       case RecommitmentStatus.MEMBER_COMMITTED:
         return {
           templateType: EmailTags.SUPERVISOR_REQUEST,

--- a/backend/src/views/blocks/member-program.njk
+++ b/backend/src/views/blocks/member-program.njk
@@ -3,7 +3,7 @@
 
 
 <p><span>Employee Name: </span>{{member}}</p>
-<p><span>Program: </span>{{program}}</p>
+<p><span>CORE Team Program: </span>{{program}}</p>
 
 
 

--- a/backend/src/views/blocks/member-steps-followup.njk
+++ b/backend/src/views/blocks/member-steps-followup.njk
@@ -1,20 +1,17 @@
-<p><span>What you need to do:
 <ol>
-<li><span>Supervisor approval</span> is required for your return to CORE Team each year. Before proceeding, please first have a conversation with your current supervisor to discuss the possibility of your return to CORE Team this year.</li>
-<li>Log in to your CORE dashboard, then <span>click "Make Recommitment Decision" to confirm or decline your recommitment status before {{date}}.</span> Please refer to the links below to find your program specific user guide.</li> 
+<li>Speak to your current supervisor to discuss the possibility of your return to CORE Team this year. <span>Supervisor approval is required for your return</span> to CORE Team each year.</li>
+<li>Log in to to your CORE Team dashboard by clicking "Go to My Dashboard" to confirm your participation for the upcoming year before {{date}}. Please refer to the links below to find your program specific user guide.</li>
 <ul>
   <li><a href="https://emcr.atlassian.net/wiki/external/NTJkNjNiMDViYjU0NGVhN2I1MWY5ZDA0ZGZkM2IzYmY">BCWS CORE Team Program Member Guide</a></li>
   <li><a href="https://emcr.atlassian.net/wiki/external/MDY2MDI1NmQwODZkNGQwNmFhNWE1NDM3ZGFjMmQxMTI">EMCR CORE Team Program Member Guide</a></li>
   <li><a href="https://emcr.atlassian.net/wiki/external/MThiNjZlY2ZmZTA5NDU3ZDk5ZWYyMGRhNjRlOTViODA">Dual CORE Team Program Member Guide</a></li>
 </ul>
+<li>Once you have confirmed your return to CORE Team, your supervisor will be notified to give approval/decline your request.</li>
+<li>If your supervisor approves of your recommitment, your member status will be automatically updated to "Recommitted" for 2025 and you will remain an active member of the approved program.</li>
 
-<li>Once you have confirmed your return to CORE, your supervisor will be notified to give approval/decline your request. If your supervisor approves of your recommitment, your member status will be automatically updated to "Recommitted" for {{year}}. </li>
-</ol>
-
-<p><span>If you plan to recommit to BCWS CORE Team:</span></p>
+<p><span>If you plan to recommit to BCWS:</span></p>
 <p>You can now directly fill in your PAR-Q+ response as part of the recommitment process in your dashboard. <span>Your PAR-Q+ responses will NOT be recorded; you must download your response once completed and email it to your Fire Centre.</span> If you have any concerns about your health conditions that may affect your deployment in the upcoming year, please inform your CORE coordinator.</p>
 
 <p>To complete the PAR-Q+, <span>you must have a witness signature.</span> Please make sure you have found someone to be your witness before starting recommitment.</p>
 
 {% include "blocks/member-button.njk" %}
-

--- a/backend/src/views/blocks/steps.njk
+++ b/backend/src/views/blocks/steps.njk
@@ -4,7 +4,7 @@
 
 <ol>
   <li>Have a conversation with your employee.</li>
-  <li>Log in to your supervisor portal with your IDIR to approve or decline this member’s CORE participation for {{year}} before <span>{{date}}</span> Please refer to the <a href="https://emcr.atlassian.net/wiki/external/ZjUyZGI4ZWU5M2RlNDJlODkyMDA4MjM5MzU0NGNlYWI">Supervisor User Manual</a> for further instructions.</li>
+  <li>Log in to your supervisor portal with your IDIR to approve or decline this member’s CORE Team participation for {{year}} <span>before {{date}}</span> Please refer to the <a href="https://emcr.atlassian.net/wiki/external/ZjUyZGI4ZWU5M2RlNDJlODkyMDA4MjM5MzU0NGNlYWI">Supervisor User Manual</a> for further instructions.</li>
   <li>If you choose to decline a member’s participation, please provide a reason with the survey tool provided in the portal.</li>
-  <li>After choosing your decision, click “Submit”. CORE coordinators and your employee will be notified of your decision.</li>
+  <li>After choosing your decision, click “Submit”. CORE Team coordinators and your employee will be notified of your decision.</li>
 </ol>

--- a/backend/src/views/layout.njk
+++ b/backend/src/views/layout.njk
@@ -109,7 +109,7 @@ h1 {
         
         {% block content %}{% endblock %}
         <p>Sincerely,</p>
-        <p>BC CORE Team</p>
+        <p>CORE Team</p>
 
       </div>
     </div>

--- a/backend/src/views/member/member-annual-reminder.njk
+++ b/backend/src/views/member/member-annual-reminder.njk
@@ -5,13 +5,13 @@
 
 <p>Hello {{member}},</p>
 
-<p>As we prepare for the upcoming {{year}} year, we kindly remind you to confirm your recommitment to CORE.</p> 
+<p>As we prepare for the upcoming {{year}} year, we kindly remind you to confirm your recommitment to CORE Team.</p> 
 
 {% include "blocks/member-steps.njk" %}
 
 <p>If you have any questions or need further assistance, feel free to reach out to: {% include "blocks/program-contact.njk" %}</p>
 
-<p>Thank you for your continued dedication to the CORE program. We look forward to another successful year!</p>
+<p>Thank you for your continued dedication to the CORE Team program. We look forward to another successful year!</p>
 {% endblock %}
 
 

--- a/backend/src/views/member/member-approved.njk
+++ b/backend/src/views/member/member-approved.njk
@@ -4,9 +4,9 @@
 
 <p>Hello {{member}},</p>
 
-<p>We are pleased to inform you that your supervisor has approved your recommitment to the <span>CORE {{program}} program</span> for {{year}}.</p>
+<p>We are pleased to inform you that your supervisor has approved your recommitment to the <span>{{program}} CORE Team program</span> for {{year}}.</p>
 
-<p>With this approval, your status in CORE will remain "Active" for {{year}}, meaning that you will be a deployable member to {{program}} CORE coordinators for emergency activations throughout the upcoming year.<p>
+<p>With this approval, your status in CORE Team will remain "Active" for {{year}}, meaning that you will be a deployable member to {{program}} CORE Team coordinators for emergency activations throughout the upcoming year.<p>
 
 <ol>
 <li>Log in to your member dashboard to ensure that your member profile is up to date.</li>
@@ -18,7 +18,7 @@
 <p>If you have any questions or need further assistance, feel free to reach out to:</p>
 {% include "blocks/program-contact.njk" %}
 
-<p>We appreciate and look forward to your continued efforts in CORE to make BC a safer place for citizens.</p>
+<p>We appreciate and look forward to your continued efforts in CORE Team to make BC a safer place for citizens.</p>
 
 
 {% endblock %}

--- a/backend/src/views/member/member-declined.njk
+++ b/backend/src/views/member/member-declined.njk
@@ -4,12 +4,12 @@
 
 <p>Hello {{member}},</p>
 
-<p> This is to confirm that you have <span>declined your recommitment to CORE for {{year}}.</span></p>
+<p> This is to confirm that you have <span>declined your recommitment to CORE Team for {{year}}.</span></p>
 
-<p><span>Program Declined: </span> {{program}}</p>
+<p><span>Program Declined: </span> {{program}} CORE Team</p>
 <p><span>Your Selected Reason: </span> {{member}}</p>
 
-<p>We are sorry to see you go! We hope to welcome you back to CORE in the future. If you wish to change your decision,
+<p>We are sorry to see you go! We hope to welcome you back to CORE Team in the future. If you wish to change your decision,
 please do so before <span>{{date}}</span>. Note that you can only change your recommitment decision <span>one more time.</span></p>
 
 {% endblock %}

--- a/backend/src/views/member/member-denied.njk
+++ b/backend/src/views/member/member-denied.njk
@@ -4,8 +4,8 @@
 
 <p>Hello {{member}},</p>
 
-<p>We regret to inform you that your recommitment to the <span>CORE {{program}} program for {{year}}</span> has been <span>declined by your supervisor.</span></p>
+<p>We regret to inform you that your recommitment to the <span>{{program}} CORE Team program for {{year}}</span> has been <span>declined by your supervisor.</span></p>
 
-<p>If you still wish to participate in CORE this year, we encourage you to speak directly with your supervisor to discuss the possibility of reconsideration. Should it not be feasible for you to join this year, we look forward to seeing you next year and will be happy to welcome you back in the future.</p>
+<p>If you still wish to participate in CORE Team this year, we encourage you to speak directly with your supervisor to discuss the possibility of reconsideration. Should it not be feasible for you to join this year, we look forward to seeing you next year and will be happy to welcome you back in the future.</p>
 
 {% endblock %}

--- a/backend/src/views/member/member-follow-up.njk
+++ b/backend/src/views/member/member-follow-up.njk
@@ -4,9 +4,9 @@
 
 <p>Hello {{member}},</p>
 
-<p>We’re still waiting to hear back from you about your CORE recommitment for {{year}}! To ensure your continued participation in CORE, please take a moment to update your recommitment status and verify your profile and supervisor information with the following steps:</p>
+<p>We’re still waiting to hear back from you about your CORE Team recommitment for {{year}}! To ensure your continued participation in CORE Team, please take a moment to update your recommitment status and verify your profile and supervisor information with the following steps:</p>
 
-{% include "blocks/member-steps.njk" %}
+{% include "blocks/member-steps-followup.njk" %}
 
 <p>Your prompt confirmation will help us finalize your participation for the upcoming year.</p>
 

--- a/backend/src/views/member/member-no-response.njk
+++ b/backend/src/views/member/member-no-response.njk
@@ -4,7 +4,7 @@
 
 <p>Hello {{member}},</p>
 
-<p>Since no action was taken on your end to confirm your recommitment for {{year}}, your CORE member status for {{program}} has been set to "Inactive”. This means you will not be called for deployments this year.</p>
+<p>Since no action was taken on your end to confirm your recommitment for {{year}}, your {{program}} CORE Team member status has been set to "Inactive”. This means you will not be called for deployments this year.</p>
 
 <p>If you would still like to participate in CORE this year, please reach out to your CORE coordinator. If you prefer to remain inactive, you may disregard this email.</p>
 

--- a/backend/src/views/member/member-reactivate.njk
+++ b/backend/src/views/member/member-reactivate.njk
@@ -8,7 +8,7 @@
 
 <p><span>Please confirm your recommitment before {{date}} using the following the instructions:</span></p>
 
-{% include "blocks/member-steps-followup.njk" %}
+{% include "blocks/member-steps.njk" %}
 
 
 <p>Your prompt confirmation will help us finalize your participation for the upcoming year.</p>

--- a/backend/src/views/member/member-reactivate.njk
+++ b/backend/src/views/member/member-reactivate.njk
@@ -4,11 +4,12 @@
 
 <p>Hello {{member}},</p>
 
-<p>You are receiving this email because you missed the initial recommitment deadline but expressed interest to us in returning to CORE for {{year}}. Your CORE coordinator has temporarily reactivated the recommitment process for you.</p>
+<p>You are receiving this email because you missed the initial recommitment deadline but expressed interest to us in returning to CORE Team for {{year}}. Your CORE Team coordinator has temporarily reactivated the recommitment process for you.</p>
 
-<p><span>Please confirm your recommitment within the next 5 days using the following the instructions:</span></p>
+<p><span>Please confirm your recommitment before {{date}} using the following the instructions:</span></p>
 
-{% include "blocks/member-steps.nj" %}
+{% include "blocks/member-steps-followup.njk" %}
+
 
 <p>Your prompt confirmation will help us finalize your participation for the upcoming year.</p>
 

--- a/backend/src/views/member/member-supervisor-no-response.njk
+++ b/backend/src/views/member/member-supervisor-no-response.njk
@@ -4,8 +4,8 @@
 
 <p>Hello {{member}},</p>
 
-<p>Since we have not received any action from your supervisor to approve your recommitment for {{year}}, your CORE member status for {{program}} has been set to "Inactive”. This means you will not be called for deployments this year.</p>
+<p>Since we have not received any action from your supervisor to approve your recommitment for {{year}}, your {{program}} CORE Team member status has been set to "Inactive”. This means you will not be called for deployments this year.</p>
 
-<p>If you would still like to participate in CORE this year, please speak to your supervisor and reach out to your CORE coordinator. If you prefer to remain inactive, you may disregard this email.</p>
+<p>If you would still like to participate in CORE Team this year, please speak to your supervisor and reach out to your CORE Team coordinator. If you prefer to remain inactive, you may disregard this email.</p>
 
 {% endblock %}

--- a/backend/src/views/supervisor/supervisor-follow-up-reminder.njk
+++ b/backend/src/views/supervisor/supervisor-follow-up-reminder.njk
@@ -4,7 +4,7 @@
 
 <p>Hello {{supervisor}},</p>
 
-<p>This is just a reminder to give or decline approval for employee(s) who have requested to recommit to the CORE program for {{year}}.</p>
+<p>This is just a reminder to give or decline approval for employee(s) who have requested to recommit to the CORE Team program for {{year}}.</p>
 
 {% include "blocks/steps.njk" %}
 

--- a/backend/src/views/supervisor/supervisor-request.njk
+++ b/backend/src/views/supervisor/supervisor-request.njk
@@ -5,13 +5,13 @@
 
 <p>Hello {{supervisor}},</p>
 
-<p>The following employee has requested to recommit to the CORE program for {{year}}:</p>
+<p>The following employee has requested to recommit to the CORE Team program for {{year}}:</p>
 
 {% include "blocks/member-program.njk" %}
  
-As their supervisor, you have the authority to approve or decline their participation in CORE for the upcoming year.
+As their supervisor, you have the authority to approve or decline their participation in CORE Team for the upcoming year.
 
-<p>Please note that this email is simply requesting your approval for the member’s participation in CORE. Once they are recommitted, <span>supervisor approval is still required for each deployment. You are NOT obligated to approve every deployment just because you have given approval for recommitment.</span></p>
+<p>Please note that this email is simply requesting your approval for the member’s participation in CORE Team. Once they are recommitted, <span>supervisor approval is still required for each deployment. You are NOT obligated to approve every deployment just because you have given approval for recommitment.</span></p>
 
 {% include "blocks/steps.njk" %}
 

--- a/frontend/src/hooks/useRecommitment.tsx
+++ b/frontend/src/hooks/useRecommitment.tsx
@@ -4,6 +4,7 @@ import { useAxios } from './useAxios';
 import { RecommitmentStatus } from '@/common/enums/recommitment-status';
 import { offsetTimezoneDate } from '@/utils';
 import type { SupervisorInformation } from '@/components/recommitment';
+import { addDays } from 'date-fns';
 
 export interface RecommitmentDecision {
   program: Program;
@@ -92,8 +93,11 @@ export const useRecommitmentCycle = () => {
     isRecommitmentReinitiationOpen:
       recommitmentCycle &&
       recommitmentCycle.reinitiationEndDate &&
-      offsetTimezoneDate(recommitmentCycle.endDate) <= new Date() &&
-      offsetTimezoneDate(recommitmentCycle.reinitiationEndDate) >= new Date(),
+      offsetTimezoneDate(addDays(recommitmentCycle.endDate, 1).toString()) <=
+        new Date() &&
+      offsetTimezoneDate(
+        addDays(recommitmentCycle.reinitiationEndDate, 1).toString(),
+      ) >= new Date(),
     updateRecommitment,
     getProfileRecommitmentStatusText,
   };


### PR DESCRIPTION
[TC-962](https://bcdevex.atlassian.net/browse/TC-962)

Email template for reactivating member
Timing changes for using end date vs. reinitiation end date
Use of PST date for the above
Changing other templates to "CORE Team"
Differentiate between member steps and member follow up steps as Chevonne mentioned they are intentionally different

[TC-962]: https://bcdevex.atlassian.net/browse/TC-962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ