### PR TITLE
[TC-925] fix: add default placeholder for pending

### DIFF
--- a/frontend/src/hooks/commonProfileData.tsx
+++ b/frontend/src/hooks/commonProfileData.tsx
@@ -1,8 +1,17 @@
-import { DriverLicenseName, DriverLicense, Member, Program, Personnel } from "@/common";
-import { LanguageProficiencyName } from "@/common/enums/language.enum";
-import { RecommitmentStatus } from "@/common/enums/recommitment-status";
-import { ToolsName, Tools, ToolsProficiencyName } from "@/common/enums/tools.enum";
-import { format, formatDate } from "date-fns";
+// common
+import {
+  DriverLicense,
+  DriverLicenseName,
+  Member,
+  Personnel,
+  Program,
+} from '@/common';
+import { LanguageProficiencyName } from '@/common/enums/language.enum';
+import { RecommitmentStatus } from '@/common/enums/recommitment-status';
+import { ToolsName, Tools, ToolsProficiencyName } from '@/common/enums/tools.enum';
+
+// util
+import { format, formatDate } from 'date-fns';
 
 export const formatDriversLicenses = (driverLicenses: string[]): string => {
   const licensesFormatted = driverLicenses.map(
@@ -57,6 +66,25 @@ export const renderRecommitmentStatus = (
       }
   }
 };
+
+const emptyMembershipDetails = [
+  {
+    title: 'Program',
+    content: '--',
+  },
+  {
+    title: 'Status',
+    content: '--',
+  },
+  {
+    title: 'Annual Recommitment',
+    content: '--',
+  },
+  {
+    title: 'Member since',
+    content: '--',
+  },
+];
 
 export const getMembershipDetails = (personnel: Member) => {
   const bcwsStatus = personnel?.recommitment?.find(
@@ -136,11 +164,10 @@ export const getMembershipDetails = (personnel: Member) => {
   } else if (bcwsMembership && emcrMembership) {
     return [...bcwsMembership, ...emcrMembership];
   }
-  return [];
+  return emptyMembershipDetails;
 };
 
-
-export const skillsData = (personnel: Personnel | Member)=> [
+export const skillsData = (personnel: Personnel | Member) => [
   {
     title: 'Languages',
     header: 'Language',
@@ -168,4 +195,4 @@ export const skillsData = (personnel: Personnel | Member)=> [
       value: c.expiry,
     })),
   },
-]
+];

--- a/frontend/src/hooks/commonProfileData.tsx
+++ b/frontend/src/hooks/commonProfileData.tsx
@@ -5,6 +5,7 @@ import {
   Member,
   Personnel,
   Program,
+  Status,
 } from '@/common';
 import { LanguageProficiencyName } from '@/common/enums/language.enum';
 import { RecommitmentStatus } from '@/common/enums/recommitment-status';
@@ -19,6 +20,30 @@ export const formatDriversLicenses = (driverLicenses: string[]): string => {
   );
   return licensesFormatted.join(', ');
 };
+
+const renderStatus = (status: Status) => {
+  switch (status) {
+    case Status.ACTIVE:
+      return (
+        <span className="bg-successBannerLight px-2 rounded-full ml-2">Active</span>
+      );
+    case Status.INACTIVE:
+      return (
+        <span className="bg-warningBannerLight px-2 rounded-full ml-2">
+          Inactive
+        </span>
+      );
+    case Status.PENDING:
+      return (
+        <span className="bg-infoBannerLight px-2 rounded-full ml-2">
+          Pending Approval
+        </span>
+      );
+    case Status.NEW:
+      return <span className="bg-infoBannerLight px-2 rounded-full ml-2">New</span>;
+  }
+};
+
 export const renderRecommitmentStatus = (
   recommitmentStatus: RecommitmentStatus,
   isRecommitmentCycleOpen?: boolean,
@@ -67,26 +92,52 @@ export const renderRecommitmentStatus = (
   }
 };
 
-const emptyMembershipDetails = [
-  {
-    title: 'Program',
-    content: '--',
-  },
-  {
-    title: 'Status',
-    content: '--',
-  },
-  {
-    title: 'Annual Recommitment',
-    content: '--',
-  },
-  {
-    title: 'Member since',
-    content: '--',
-  },
-];
-
 export const getMembershipDetails = (personnel: Member) => {
+  // default membership
+  let defaultMembershipDetails = [];
+  if (Object.keys(personnel).includes('emcr')) {
+    const status = personnel.emcr?.status;
+    defaultMembershipDetails.push(
+      {
+        title: 'Program',
+        content: Program.EMCR.toUpperCase(),
+      },
+      {
+        title: 'Status',
+        content: (status && renderStatus(status)) || '--',
+      },
+      {
+        title: 'Annual Recommitment',
+        content: '--',
+      },
+      {
+        title: 'Member since',
+        content: '--',
+      },
+    );
+  }
+  if (Object.keys(personnel).includes('bcws')) {
+    const status = personnel.bcws?.status;
+    defaultMembershipDetails.push(
+      {
+        title: 'Program',
+        content: Program.BCWS.toUpperCase(),
+      },
+      {
+        title: 'Status',
+        content: (status && renderStatus(status)) || '--',
+      },
+      {
+        title: 'Annual Recommitment',
+        content: '--',
+      },
+      {
+        title: 'Member since',
+        content: '--',
+      },
+    );
+  }
+
   const bcwsStatus = personnel?.recommitment?.find(
     (itm) => itm.program === Program.BCWS,
   )?.status;
@@ -164,7 +215,8 @@ export const getMembershipDetails = (personnel: Member) => {
   } else if (bcwsMembership && emcrMembership) {
     return [...bcwsMembership, ...emcrMembership];
   }
-  return emptyMembershipDetails;
+
+  return defaultMembershipDetails;
 };
 
 export const skillsData = (personnel: Personnel | Member) => [


### PR DESCRIPTION
Ticket:
https://emcr.atlassian.net/browse/TC-925

Description:
- Added a default empty `MembershipDetails` object that applies to the personnel who don't have entries in the `recommitment` table
- This makes sure that the placeholder empty data is still displayed, otherwise the whole section is empty and it was confusing for the client

Screenshots:
1) Before:
![image](https://github.com/user-attachments/assets/f6a4c067-e30c-4630-8959-69226fa8d976)

2) After:
![image](https://github.com/user-attachments/assets/b8e93cf0-ace6-4bea-9264-20e0f03b4257)

3) With data present in `recommitment` for that `personnel_id`:
![image](https://github.com/user-attachments/assets/a9f1a181-0969-49ba-b99c-a613061fbb95)
