### PR TITLE
[TC-980] fix: add loader to dashboard

### DIFF
--- a/frontend/src/components/ui/Table.tsx
+++ b/frontend/src/components/ui/Table.tsx
@@ -1,7 +1,12 @@
+// react
+import { Fragment, type ReactElement } from 'react';
+
+// ui
 import type { Cell, Row } from '@/components';
 import { Loading, TableBodyCell } from '@/components';
+
+// hooks
 import { useRecommitmentCycle } from '@/hooks/useRecommitment';
-import { Fragment, type ReactElement } from 'react';
 
 export const Table = ({
   loading,
@@ -16,94 +21,93 @@ export const Table = ({
 }) => {
   const { isRecommitmentCycleOpen } = useRecommitmentCycle();
   return (
-    <table
-      className={`${auto ? 'table-auto ' : 'table-fixed '} w-full border-collapse border border-slate-500`}
-    >
-      <thead>
-        <tr>
-          {columns?.map((col: ReactElement, index: number) => (
-            <th
-              key={index}
-              scope="col"
-              className={`px-2 bg-white  border-t-2 border-t-slate-500 text-nowrap  text-dark text-left h-[64px] py-2 border-b-2 border-b-primaryBlue`}
-            >
-              {col.props.children}
-            </th>
-          ))}
-        </tr>
-      </thead>
-
-      <tbody>
-        
-        {loading && 
-              <tr>
-            <td colSpan={columns?.length}>
-              <Loading />
-            </td>
-          </tr>
-
-            
-          } 
-            
-          {rows.length === 0 ? <>
-          
-          <tr className='h-36'><td colSpan={columns?.length}><h6 className="text-center">No Data Found...</h6></td></tr>
-          
-          </> : rows?.map((row: Row, index: number) => (
-            <Fragment key={index}>
-              {index !== 0 && (
-                <tr>
-                  <td
-                    className={`border-b-2 border-slate-500`}
-                    colSpan={row.cells?.length}
-                  ></td>
+    <div>
+      {loading ? (
+        <div className={'flex p-4'}>{loading && <Loading height={'50'} />}</div>
+      ) : (
+        <table
+          className={`${auto ? 'table-auto ' : 'table-fixed '} w-full border-collapse border border-slate-500`}
+        >
+          <thead>
+            <tr>
+              {columns?.map((col: ReactElement, index: number) => (
+                <th
+                  key={index}
+                  scope="col"
+                  className={`px-2 bg-white  border-t-2 border-t-slate-500 text-nowrap  text-dark text-left h-[64px] py-2 border-b-2 border-b-primaryBlue`}
+                >
+                  {col.props.children}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.length === 0 ? (
+              <>
+                <tr className="h-36">
+                  <td colSpan={columns?.length}>
+                    <h6 className="text-center">No Data Found...</h6>
+                  </td>
                 </tr>
-              )}
-              <tr key={row.key} id={row.key}>
-                {row.cells.map((itm: Cell) => (
-                  <Fragment key={itm.key}>
-                    <td
-                      key={itm.key}
-                      scope="row"
-                      className={`py-4 px-4 text-nowrap truncate max-w-[250px]`}
-                    >
-                      <TableBodyCell
-                        key={itm.key}
-                        cell={itm}
-                        id={row.key}
-                        status={row.status}
-                        recommitmentStatus={row?.recommitmentStatus}
-                        isRecommitmentCycleOpen={isRecommitmentCycleOpen}
-                      />
-                    </td>
-                    {itm.nested && itm.nested.length > 0 && (
-                      <table className="bg-red-200">
-                        {itm.nested.map((nestedRow) => (
-                          <tr key={nestedRow.key} id={nestedRow.key}>
-                            {nestedRow?.cells.map((cell) => (
-                              <td
-                                key={cell.key}
-                                scope="row"
-                                className={`py-4 px-4 text-nowrap truncate max-w-[250px]`}
-                              >
-                                <TableBodyCell
-                                  key={cell.key}
-                                  cell={cell}
-                                  id={nestedRow.key}
-                                />
-                              </td>
+              </>
+            ) : (
+              rows?.map((row: Row, index: number) => (
+                <Fragment key={index}>
+                  {index !== 0 && (
+                    <tr>
+                      <td
+                        className={`border-b-2 border-slate-500`}
+                        colSpan={row.cells?.length}
+                      ></td>
+                    </tr>
+                  )}
+                  <tr key={row.key} id={row.key}>
+                    {row.cells.map((itm: Cell) => (
+                      <Fragment key={itm.key}>
+                        <td
+                          key={itm.key}
+                          scope="row"
+                          className={`py-4 px-4 text-nowrap truncate max-w-[250px]`}
+                        >
+                          <TableBodyCell
+                            key={itm.key}
+                            cell={itm}
+                            id={row.key}
+                            status={row.status}
+                            recommitmentStatus={row?.recommitmentStatus}
+                            isRecommitmentCycleOpen={isRecommitmentCycleOpen}
+                          />
+                        </td>
+                        {itm.nested && itm.nested.length > 0 && (
+                          <table className="bg-red-200">
+                            {itm.nested.map((nestedRow) => (
+                              <tr key={nestedRow.key} id={nestedRow.key}>
+                                {nestedRow?.cells.map((cell) => (
+                                  <td
+                                    key={cell.key}
+                                    scope="row"
+                                    className={`py-4 px-4 text-nowrap truncate max-w-[250px]`}
+                                  >
+                                    <TableBodyCell
+                                      key={cell.key}
+                                      cell={cell}
+                                      id={nestedRow.key}
+                                    />
+                                  </td>
+                                ))}
+                              </tr>
                             ))}
-                          </tr>
-                        ))}
-                      </table>
-                    )}
-                  </Fragment>
-                ))}
-              </tr>
-            </Fragment>
-          ))
-        }
-      </tbody>
-    </table>
+                          </table>
+                        )}
+                      </Fragment>
+                    ))}
+                  </tr>
+                </Fragment>
+              ))
+            )}
+          </tbody>
+        </table>
+      )}
+    </div>
   );
 };


### PR DESCRIPTION
Ticket:
https://emcr.atlassian.net/browse/TC-980

Description:
- Added a loader icon for data that is still being processed on the dashboard
- The loader goes away after the data is loaded

Screenshots:
![image](https://github.com/user-attachments/assets/e2ce113f-3d26-48f8-908b-160ff4b1270a)

QA Instructions:
- In order to see the loader, add `true` to the following line in `Dashboard.tsx`:
![image](https://github.com/user-attachments/assets/fb9766b8-ab7a-4a2f-bfae-331c9b3bc944)
