### PR TITLE
[TC-972] fix: add missing elements for splash screen

### DIFF
--- a/frontend/src/pages/SplashPage.tsx
+++ b/frontend/src/pages/SplashPage.tsx
@@ -30,7 +30,7 @@ const SplashPage = () => {
     title: 'Welcome to CORE Team',
     subtitle: 'Coordinated Operation Response in Emergencies',
     description: {
-      pt1: 'This is the staffing system (previously known as TEAMS – Temporary Emergency Assignment Management System) that maintains a roster of employees from numerous ministries in the BC Government who have a combination of interest, skills, and experience to work within EMCR operation centres and BCWS fire centres to support communities in emergency management and wildfire response across the province.',
+      pt1: 'This is the staffing system that maintains a roster of employees from numerous ministries in the BC Government who have a combination of interest, skills, and experience to work within Emergency Management and Climate Readiness (EMCR) operation centres and BC Wildfire Service (BCWS) centres to support communities in emergency management and wildfire response across the province.',
     },
     login: {
       title: 'Login',
@@ -74,8 +74,50 @@ const SplashPage = () => {
               <span className="text-info lg:mt-32">{content.subtitle}</span>
               <h1 className="font-bold pt-8 pb-16">{content.title}</h1>
             </div>
-            <div>
+            <div className="flex flex-col gap-16">
               <p className="leading-loose">{content.description.pt1}</p>
+              <div>
+                <p className="font-bold">
+                  To learn more about each CORE Team program stream, visit:{' '}
+                </p>
+                <ul className="list-disc list-inside text-primaryBlue">
+                  <li>
+                    <a href="#" className="hover:underline">
+                      EMCR CORE Team program stream intranet page{' '}
+                    </a>
+                  </li>
+                  <li>
+                    <a href="#" className="hover:underline">
+                      BCWS CORE Team program stream intranet page{' '}
+                    </a>
+                  </li>
+                </ul>
+              </div>
+              <div className="w-full drop-shadow-md rounded-md">
+                <div className="w-full bg-grayBackground px-[24px] py-[12px]">
+                  <p className="font-bold text-lg">Contact Information</p>
+                </div>
+                <div className="w-full bg-white pt-[16px] pb-[24px] px-[24px] flex flex-col gap-[16px]">
+                  <div>
+                    <p className="font-bold">EMCR CORE Team:</p>
+                    <a
+                      className="text-primaryBlue hover:underline"
+                      href="mailto:EMCR.CORETeam@gov.bc.ca"
+                    >
+                      EMCR.CORETeam@gov.bc.ca
+                    </a>
+                  </div>
+                  <div>
+                    <p className="font-bold">BCWS CORE Team:</p>
+                    <a
+                      className="text-primaryBlue hover:underline"
+                      href="mailto:BCWS.CORETeam@gov.bc.ca"
+                    >
+                      EMCR.CORETeam@gov.bc.ca
+                    </a>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
           {/* Small Screen Login in Section */}

--- a/frontend/src/pages/SplashPage.tsx
+++ b/frontend/src/pages/SplashPage.tsx
@@ -82,12 +82,22 @@ const SplashPage = () => {
                 </p>
                 <ul className="list-disc list-inside text-primaryBlue">
                   <li>
-                    <a href="#" className="hover:underline">
+                    <a
+                      href="https://intranet.gov.bc.ca/emcr/employees-workplace/hr/core-team"
+                      className="hover:underline"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
                       EMCR CORE Team program stream intranet page{' '}
                     </a>
                   </li>
                   <li>
-                    <a href="#" className="hover:underline">
+                    <a
+                      href="https://intranet.gov.bc.ca/bcws/core-team"
+                      className="hover:underline"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
                       BCWS CORE Team program stream intranet page{' '}
                     </a>
                   </li>


### PR DESCRIPTION
Ticket:
https://emcr.atlassian.net/browse/TC-972

Description:
- Added some missing text elements to the splash screen
- Made sure they look like the figma designs

Screenshots:
![image](https://github.com/user-attachments/assets/74492993-8595-40f8-85f7-dfb6a263dc22)

Note:
Need to insert links to the `<a>` elements still, pending on Chevonne.