### PR TITLE
[TC-949] Rename Missed Recommitment -> Missed Deadline

### DIFF
--- a/frontend/src/common/enums/status.enum.ts
+++ b/frontend/src/common/enums/status.enum.ts
@@ -23,7 +23,7 @@ export const StatusLabels: Record<string, string> = {
   ALL: 'All',
   INACTIVE: 'Inactive',
   MEMBER_DECLINED: 'Member Declined - Not Returning',
-  MISSED: 'Missed Recommitment',
+  MISSED: 'Missed Deadline',
   NEW: 'New',
   OTHER: 'Other',
   PENDING: 'Pending',


### PR DESCRIPTION
Renamed the enum according to the client's request.