### PR TITLE
[TC-974] Enable Export of Data From Database

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -26,6 +26,7 @@
         "cron-validator": "1.3.1",
         "date-fns": "3.3.1",
         "helmet": "7.1.0",
+        "json-2-csv": "^5.5.9",
         "jsonwebtoken": "9.0.2",
         "nest-winston": "1.9.4",
         "nestjs-cls": "4.5.0",
@@ -4578,6 +4579,14 @@
         }
       }
     },
+    "node_modules/deeks": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/deeks/-/deeks-3.1.0.tgz",
+      "integrity": "sha512-e7oWH1LzIdv/prMQ7pmlDlaVoL64glqzvNgkgQNgyec9ORPHrT2jaOqMtRyqJuwWjtfb6v+2rk9pmaHj+F137A==",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "dev": true,
@@ -4699,6 +4708,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/doc-path": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/doc-path/-/doc-path-4.1.1.tgz",
+      "integrity": "sha512-h1ErTglQAVv2gCnOpD3sFS6uolDbOKHDU1BZq+Kl3npPqroU3dYL42lUgMfd5UimlwtRgp7C9dLGwqQ5D2HYgQ==",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/doctrine": {
@@ -7680,6 +7697,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/json-2-csv": {
+      "version": "5.5.9",
+      "resolved": "https://registry.npmjs.org/json-2-csv/-/json-2-csv-5.5.9.tgz",
+      "integrity": "sha512-l4g6GZVHrsN+5SKkpOmGNSvho+saDZwXzj/xmcO0lJAgklzwsiqy70HS5tA9djcRvBEybZ9IF6R1MDFTEsaOGQ==",
+      "dependencies": {
+        "deeks": "3.1.0",
+        "doc-path": "4.1.1"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/json-buffer": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -50,6 +50,7 @@
     "cron-validator": "1.3.1",
     "date-fns": "3.3.1",
     "helmet": "7.1.0",
+    "json-2-csv": "^5.5.9",
     "jsonwebtoken": "9.0.2",
     "nest-winston": "1.9.4",
     "nestjs-cls": "4.5.0",

--- a/backend/src/bcws/bcws.service.ts
+++ b/backend/src/bcws/bcws.service.ts
@@ -216,7 +216,7 @@ export class BcwsService {
    * Get BCWS Personnel for CSV Export
    * Extracts full raw JSON list of all BCWS-flagged personnel
    * and associated table columns for export to CSV file
-   * @returns {string} List of personnel, converted to JSON string
+   * @returns {BcwsPersonnelEntity[]} List of personnel, converted to JSON string
    */
   async getBcwsPersonnelforCSV(): Promise<BcwsPersonnelEntity[]> {
     const qb =

--- a/backend/src/bcws/bcws.service.ts
+++ b/backend/src/bcws/bcws.service.ts
@@ -17,6 +17,7 @@ import {
 } from './dto/update-bcws-personnel-roles.dto';
 import { UpdateBcwsPersonnelDTO } from './dto/update-bcws-personnel.dto';
 import { BcwsRole, BcwsRoleName, SectionName, Status } from '../common/enums';
+import { AvailabilityEntity } from '../database/entities/personnel/availability.entity';
 
 @Injectable()
 export class BcwsService {
@@ -216,12 +217,26 @@ export class BcwsService {
    * Get BCWS Personnel for CSV Export
    * Extracts full raw JSON list of all BCWS-flagged personnel
    * and associated table columns for export to CSV file
-   * @returns {BcwsPersonnelEntity[]} List of personnel, converted to JSON string
+   * @returns {Entity[]} Merged TypeORM list of personnel, converted to JSON string
    */
   async getBcwsPersonnelforCSV(): Promise<BcwsPersonnelEntity[]> {
     const qb =
       this.bcwsPersonnelRepository.createQueryBuilder('bcws_personnel');
-    qb.leftJoinAndSelect('bcws_personnel.personnel', 'personnel');
+    //join with personnel table and append last deployed date as subselection
+    qb.leftJoinAndSelect('bcws_personnel.personnel', 'personnel').addSelect(
+      (subQuery) => {
+        return subQuery
+          .select('availability.date')
+          .from(AvailabilityEntity, 'availability')
+          .where('availability.personnel = personnel.id')
+          .andWhere('availability.availabilityType = :type', {
+            type: 'DEPLOYED',
+          })
+          .orderBy('availability.date', 'DESC')
+          .take(1);
+      },
+      'last_deployed',
+    );
     qb.leftJoinAndSelect('personnel.homeLocation', 'home_loc');
     qb.leftJoinAndSelect('personnel.workLocation', 'work_loc');
     qb.leftJoinAndSelect('personnel.recommitment', 'recommitment');

--- a/backend/src/bcws/bcws.service.ts
+++ b/backend/src/bcws/bcws.service.ts
@@ -213,6 +213,26 @@ export class BcwsService {
   }
 
   /**
+   * Get BCWS Personnel for CSV Export
+   * Extracts full raw JSON list of all BCWS-flagged personnel
+   * and associated table columns for export to CSV file
+   * @returns {string} List of personnel, converted to JSON string
+   */
+  async getBcwsPersonnelforCSV(): Promise<BcwsPersonnelEntity[]> {
+    const qb =
+      this.bcwsPersonnelRepository.createQueryBuilder('bcws_personnel');
+    qb.leftJoinAndSelect('bcws_personnel.personnel', 'personnel');
+    qb.leftJoinAndSelect('personnel.homeLocation', 'home_loc');
+    qb.leftJoinAndSelect('personnel.workLocation', 'work_loc');
+    qb.leftJoinAndSelect('personnel.recommitment', 'recommitment');
+    qb.leftJoinAndSelect('recommitment.recommitmentCycle', 'recommitmentCycle');
+
+    const personnel = await qb.getRawMany();
+
+    return personnel;
+  }
+
+  /**
    * Get Personnel By ID
    * Returns a default availability range of 31 days for a single personnel
    * @returns {EmcrPersonnelEntity} Single personnel

--- a/backend/src/common/enums/bcws/csv-headers.ts
+++ b/backend/src/common/enums/bcws/csv-headers.ts
@@ -1,0 +1,161 @@
+/*
+NOTE: this is not strictly an enumeration but is kept in the enums/bcws folder
+for convenience, this const is used to assign human-readable headers to CSV output
+using preassigned key-value pairings
+
+Any future adjustments to the CSV output data will require adding the appropriate
+header replacements to this const (with getRawMany(), all field names are generated
+based on their respective DB table/column (or TypeORM alias) name regardless of joins;
+for instance, personnel.first_name becomes 'personnel_first_name')
+
+Columns labelled "Internal Use" are linking PKs and the like, they don't have much
+reporting value but TypeORM's select logic makes excluding them prohibitively difficult
+so they're labelled for convenient removal for future reporting purposes
+*/
+
+export const BcwsCsvHeaders = [
+  {
+    field: 'bcws_personnel_personnel_id',
+    title: 'BCWS Personnel ID (Internal Use)',
+  },
+  { field: 'bcws_personnel_status', title: 'Status' },
+  { field: 'bcws_personnel_date_applied', title: 'Date Applied' },
+  { field: 'bcws_personnel_date_approved', title: 'Date Approved' },
+  {
+    field: 'bcws_personnel_approved_by_supervisor',
+    title: 'Approved by Supervisor',
+  },
+  {
+    field: 'bcws_personnel_purchase_card_holder',
+    title: 'Purchase Card Holder',
+  },
+  {
+    field: 'bcws_personnel_liason_first_name',
+    title: 'BCWS Liaison First Name',
+  },
+  { field: 'bcws_personnel_liason_last_name', title: 'BCWS Liaison Last Name' },
+  { field: 'bcws_personnel_liason_phone_number', title: 'BCWS Liaison Phone' },
+  { field: 'bcws_personnel_liason_email', title: 'BCWS Liaison Email' },
+  {
+    field: 'bcws_personnel_coordinator_notes',
+    title: 'BCWS Coordinator Notes',
+  },
+  { field: 'bcws_personnel_logistics_notes', title: 'BCWS Logistics Notes' },
+  {
+    field: 'bcws_personnel_willingess_statement',
+    title: 'Willingness Statement Signed',
+  },
+  { field: 'bcws_personnel_par_q', title: 'ParQ Completed' },
+  {
+    field: 'bcws_personnel_workplace_policy',
+    title: 'Workplace Policy Training',
+  },
+  { field: 'bcws_personnel_orientation', title: 'Orientation' },
+  { field: 'bcws_personnel_travel_preference', title: 'Travel Preference' },
+  {
+    field: 'bcws_personnel_first_choice_section',
+    title: 'First Choice Section',
+  },
+  {
+    field: 'bcws_personnel_second_choice_section',
+    title: 'Second Choice Section',
+  },
+  {
+    field: 'bcws_personnel_third_choice_section',
+    title: 'Third Choice Section',
+  },
+  { field: 'personnel_created_at', title: 'Date Created' },
+  { field: 'personnel_updated_at', title: 'Date Updated' },
+  { field: 'personnel_id', title: 'General Personnel ID (Internal Use)' },
+  { field: 'personnel_first_name', title: 'First Name' },
+  { field: 'personnel_last_name', title: 'Last Name' },
+  { field: 'personnel_primary_phone', title: 'Primary Phone' },
+  { field: 'personnel_secondary_phone', title: 'Secondary Phone' },
+  { field: 'personnel_other_phone', title: 'Other Phone' },
+  { field: 'personnel_email', title: 'Email' },
+  { field: 'personnel_supervisor_first_name', title: 'Supervisor First Name' },
+  { field: 'personnel_supervisor_last_name', title: 'Supervisor Last Name' },
+  { field: 'personnel_supervisor_email', title: 'Supervisor Email' },
+  { field: 'personnel_supervisor_phone', title: 'Supervisor Phone' },
+  { field: 'personnel_union_membership', title: 'Union Membership' },
+  { field: 'personnel_intake_form_id', title: 'Intake Form ID' },
+  { field: 'personnel_driver_licenses', title: 'Driving Licenses' },
+  { field: 'personnel_jobTitle', title: 'Job Title' },
+  { field: 'personnel_ministry', title: 'Ministry' },
+  { field: 'personnel_division', title: 'Division' },
+  {
+    field: 'personnel_emergency_contact_first_name',
+    title: 'Emergency Contact First Name',
+  },
+  {
+    field: 'personnel_emergency_contact_last_name',
+    title: 'Emergency Contact Last Name',
+  },
+  {
+    field: 'personnel_emergency_contact_phone_number',
+    title: 'Emergency Contact Phone',
+  },
+  {
+    field: 'personnel_emergency_contact_relationship',
+    title: 'Emergency Contact Relationship',
+  },
+  { field: 'personnel_employee_id', title: 'Employee ID Number' },
+  { field: 'personnel_paylist_id', title: 'Paylist ID Number' },
+  {
+    field: 'personnel_availability_confirmed_until',
+    title: 'Availability Confirmed Until',
+  },
+  {
+    field: 'personnel_availability_confirmed_on',
+    title: 'Availability Confirmed On',
+  },
+  {
+    field: 'personnel_work_location',
+    title: 'Work Location ID (Internal Use)',
+  },
+  {
+    field: 'personnel_home_location',
+    title: 'Home Location ID (Internal Use)',
+  },
+  { field: 'home_loc_id', title: 'Home Location ID (Internal Use)' },
+  { field: 'home_loc_location_name', title: 'Home Location Name' },
+  { field: 'home_loc_region', title: 'Home Region' },
+  { field: 'home_loc_fire_centre', title: 'Home Fire Centre' },
+  { field: 'home_loc_fire_zone', title: 'Home Fire Zone' },
+  { field: 'work_loc_id', title: 'Work Location ID (Internal Use)' },
+  { field: 'work_loc_location_name', title: 'Work Location Name' },
+  { field: 'work_loc_region', title: 'Work Region' },
+  { field: 'work_loc_fire_centre', title: 'Work Fire Centre' },
+  { field: 'work_loc_fire_zone', title: 'Work Fire Zone' },
+  { field: 'recommitment_personnel', title: 'Recommitment - Personnel ID' },
+  { field: 'recommitment_year', title: 'Recommitment Year' },
+  { field: 'recommitment_program', title: 'Recommitment Program' },
+  { field: 'recommitment_status', title: 'Recommitment Status' },
+  {
+    field: 'recommitment_member_decision_date',
+    title: 'Member Recommitment Decision Date',
+  },
+  { field: 'recommitment_member_reason', title: 'Member Recommitment Reason' },
+  { field: 'recommitment_supervisor_idir', title: 'Supervisor IDIR' },
+  {
+    field: 'recommitment_supervisor_decision_date',
+    title: 'Supervisor Recommitment Decision Date',
+  },
+  {
+    field: 'recommitment_supervisor_reason',
+    title: 'Supervisor Recommitment Reason',
+  },
+  {
+    field: 'recommitmentCycle_year',
+    title: 'Recommitment Cycle Year (Internal Use)',
+  },
+  {
+    field: 'recommitmentCycle_start_date',
+    title: 'Recommitment Cycle Start Date',
+  },
+  { field: 'recommitmentCycle_end_date', title: 'Recommitment Cycle End Date' },
+  {
+    field: 'recommitmentCycle_reinitiation_end_date',
+    title: 'Recommitment Cycle Reinitiation End Date',
+  },
+];

--- a/backend/src/common/enums/bcws/csv-headers.ts
+++ b/backend/src/common/enums/bcws/csv-headers.ts
@@ -6,7 +6,9 @@ using preassigned key-value pairings
 Any future adjustments to the CSV output data will require adding the appropriate
 header replacements to this const (with getRawMany(), all field names are generated
 based on their respective DB table/column (or TypeORM alias) name regardless of joins;
-for instance, personnel.first_name becomes 'personnel_first_name')
+for instance, personnel.first_name becomes 'personnel_first_name').  Note also that
+any additional columns added to existing tables also need to be accounted for here
+due to the way TypeORM handles joins
 
 Columns labelled "Internal Use" are linking PKs and the like, they don't have much
 reporting value but TypeORM's select logic makes excluding them prohibitively difficult
@@ -110,6 +112,34 @@ export const BcwsCsvHeaders = [
     title: 'Availability Confirmed On',
   },
   {
+    field: 'personnel_chips_last_ping',
+    title: 'CHIPS - Last Ping',
+  },
+  {
+    field: 'personnel_chips_last_action_date',
+    title: 'CHIPS - Last Action Date',
+  },
+  {
+    field: 'personnel_chips_profile_missing',
+    title: 'CHIPS - Profile Missing',
+  },
+  {
+    field: 'personnel_chips_last_updated_properties',
+    title: 'CHIPS - Last Updated Properties',
+  },
+  {
+    field: 'personnel_chips_issues',
+    title: 'CHIPS - Issues',
+  },
+  {
+    field: 'personnel_chips_ignore_properties',
+    title: 'CHIPS - Ignore Properties',
+  },
+  {
+    field: 'personnel_chips_training_data',
+    title: 'CHIPS - Training Data',
+  },
+  {
     field: 'personnel_work_location',
     title: 'Work Location ID (Internal Use)',
   },
@@ -158,4 +188,5 @@ export const BcwsCsvHeaders = [
     field: 'recommitmentCycle_reinitiation_end_date',
     title: 'Recommitment Cycle Reinitiation End Date',
   },
+  { field: 'last_deployed', title: 'Last Deployed Date' },
 ];

--- a/backend/src/common/enums/bcws/csv-headers.ts
+++ b/backend/src/common/enums/bcws/csv-headers.ts
@@ -9,17 +9,9 @@ based on their respective DB table/column (or TypeORM alias) name regardless of 
 for instance, personnel.first_name becomes 'personnel_first_name').  Note also that
 any additional columns added to existing tables also need to be accounted for here
 due to the way TypeORM handles joins
-
-Columns labelled "Internal Use" are linking PKs and the like, they don't have much
-reporting value but TypeORM's select logic makes excluding them prohibitively difficult
-so they're labelled for convenient removal for future reporting purposes
 */
 
 export const BcwsCsvHeaders = [
-  {
-    field: 'bcws_personnel_personnel_id',
-    title: 'BCWS Personnel ID (Internal Use)',
-  },
   { field: 'bcws_personnel_status', title: 'Status' },
   { field: 'bcws_personnel_date_applied', title: 'Date Applied' },
   { field: 'bcws_personnel_date_approved', title: 'Date Approved' },
@@ -68,7 +60,6 @@ export const BcwsCsvHeaders = [
   },
   { field: 'personnel_created_at', title: 'Date Created' },
   { field: 'personnel_updated_at', title: 'Date Updated' },
-  { field: 'personnel_id', title: 'General Personnel ID (Internal Use)' },
   { field: 'personnel_first_name', title: 'First Name' },
   { field: 'personnel_last_name', title: 'Last Name' },
   { field: 'personnel_primary_phone', title: 'Primary Phone' },
@@ -139,20 +130,10 @@ export const BcwsCsvHeaders = [
     field: 'personnel_chips_training_data',
     title: 'CHIPS - Training Data',
   },
-  {
-    field: 'personnel_work_location',
-    title: 'Work Location ID (Internal Use)',
-  },
-  {
-    field: 'personnel_home_location',
-    title: 'Home Location ID (Internal Use)',
-  },
-  { field: 'home_loc_id', title: 'Home Location ID (Internal Use)' },
   { field: 'home_loc_location_name', title: 'Home Location Name' },
   { field: 'home_loc_region', title: 'Home Region' },
   { field: 'home_loc_fire_centre', title: 'Home Fire Centre' },
   { field: 'home_loc_fire_zone', title: 'Home Fire Zone' },
-  { field: 'work_loc_id', title: 'Work Location ID (Internal Use)' },
   { field: 'work_loc_location_name', title: 'Work Location Name' },
   { field: 'work_loc_region', title: 'Work Region' },
   { field: 'work_loc_fire_centre', title: 'Work Fire Centre' },
@@ -174,10 +155,6 @@ export const BcwsCsvHeaders = [
   {
     field: 'recommitment_supervisor_reason',
     title: 'Supervisor Recommitment Reason',
-  },
-  {
-    field: 'recommitmentCycle_year',
-    title: 'Recommitment Cycle Year (Internal Use)',
   },
   {
     field: 'recommitmentCycle_start_date',

--- a/backend/src/common/enums/bcws/index.ts
+++ b/backend/src/common/enums/bcws/index.ts
@@ -3,3 +3,4 @@ export * from './sections-roles.enum';
 export * from './skills-certifications.enum';
 export * from './language.enum';
 export * from './tools.enum';
+export * from './csv-headers';

--- a/backend/src/common/enums/emcr/csv-headers.ts
+++ b/backend/src/common/enums/emcr/csv-headers.ts
@@ -1,0 +1,160 @@
+/*
+NOTE: this is not strictly an enumeration but is kept in the enums/ecmr folder
+for convenience, this const is used to assign human-readable headers to CSV output
+using preassigned key-value pairings
+
+Any future adjustments to the CSV output data will require adding the appropriate
+header replacements to this const (with getRawMany(), all field names are generated
+based on their respective DB table/column (or TypeORM alias) name regardless of joins;
+for instance, personnel.first_name becomes 'personnel_first_name')
+
+Columns labelled "Internal Use" are linking PKs and the like, they don't have much
+reporting value but TypeORM's select logic makes excluding them prohibitively difficult
+so they're labelled for convenient removal for future reporting purposes
+*/
+
+export const EmcrCsvHeaders = [
+  {
+    field: 'emcr_personnel_personnel_id',
+    title: 'EMCR Personnel ID (Internal Use)',
+  },
+  { field: 'emcr_personnel_date_approved', title: 'Date Approved' },
+  { field: 'emcr_personnel_date_applied', title: 'Date Applied' },
+  {
+    field: 'emcr_personnel_approved_by_supervisor',
+    title: 'Approved by Supervisor',
+  },
+  {
+    field: 'emcr_personnel_first_choice_section',
+    title: 'First Choice Section',
+  },
+  {
+    field: 'emcr_personnel_second_choice_section',
+    title: 'Second Choice Section',
+  },
+  {
+    field: 'emcr_personnel_third_choice_section',
+    title: 'Third Choice Section',
+  },
+  {
+    field: 'emcr_personnel_coordinator_notes',
+    title: 'EMCR Coordinator Notes',
+  },
+  { field: 'emcr_personnel_logistics_notes', title: 'EMCR Logistics Notes' },
+  { field: 'emcr_personnel_status', title: 'Status' },
+  { field: 'emcr_personnel_first_aid_level', title: 'First Aid Level' },
+  { field: 'emcr_personnel_first_aid_expiry', title: 'First Aid Expiry Date' },
+  {
+    field: 'emcr_personnel_psychological_first_aid',
+    title: 'Psychological First Aid',
+  },
+  {
+    field: 'emcr_personnel_first_nation_exp_living',
+    title: 'First Nations - Living Experience',
+  },
+  {
+    field: 'emcr_personnel_first_nation_exp_working',
+    title: 'First Nations - Working Experience',
+  },
+  { field: 'emcr_personnel_travel_preference', title: 'Travel Preference' },
+  {
+    field: 'emcr_personnel_emergency_exp',
+    title: 'Emergency Support Services Experience',
+  },
+  { field: 'emcr_personnel_pecc_exp', title: 'PECC Experience' },
+  { field: 'emcr_personnel_preoc_exp', title: 'PREOC Experience' },
+  { field: 'personnel_created_at', title: 'Date Created' },
+  { field: 'personnel_updated_at', title: 'Date Updated' },
+  { field: 'personnel_id', title: 'General Personnel ID (Internal Use)' },
+  { field: 'personnel_first_name', title: 'First Name' },
+  { field: 'personnel_last_name', title: 'Last Name' },
+  { field: 'personnel_primary_phone', title: 'Primary Phone' },
+  { field: 'personnel_secondary_phone', title: 'Secondary Phone' },
+  { field: 'personnel_other_phone', title: 'Other Phone' },
+  { field: 'personnel_email', title: 'Email' },
+  { field: 'personnel_supervisor_first_name', title: 'Supervisor First Name' },
+  { field: 'personnel_supervisor_last_name', title: 'Supervisor Last Name' },
+  { field: 'personnel_supervisor_email', title: 'Supervisor Email' },
+  { field: 'personnel_supervisor_phone', title: 'Supervisor Phone' },
+  { field: 'personnel_union_membership', title: 'Union Membership' },
+  { field: 'personnel_intake_form_id', title: 'Intake Form ID' },
+  { field: 'personnel_driver_licenses', title: 'Driving Licenses' },
+  { field: 'personnel_jobTitle', title: 'Job Title' },
+  { field: 'personnel_ministry', title: 'Ministry' },
+  { field: 'personnel_division', title: 'Division' },
+  {
+    field: 'personnel_emergency_contact_first_name',
+    title: 'Emergency Contact First Name',
+  },
+  {
+    field: 'personnel_emergency_contact_last_name',
+    title: 'Emergency Contact Last Name',
+  },
+  {
+    field: 'personnel_emergency_contact_phone_number',
+    title: 'Emergency Contact Phone',
+  },
+  {
+    field: 'personnel_emergency_contact_relationship',
+    title: 'Emergency Contact Relationship',
+  },
+  { field: 'personnel_employee_id', title: 'Employee ID Number' },
+  { field: 'personnel_paylist_id', title: 'Paylist ID Number' },
+  {
+    field: 'personnel_availability_confirmed_until',
+    title: 'Availability Confirmed Until',
+  },
+  {
+    field: 'personnel_availability_confirmed_on',
+    title: 'Availability Confirmed On',
+  },
+  {
+    field: 'personnel_work_location',
+    title: 'Work Location ID (Internal Use)',
+  },
+  {
+    field: 'personnel_home_location',
+    title: 'Home Location ID (Internal Use)',
+  },
+  { field: 'home_loc_id', title: 'Home Location ID (Internal Use)' },
+  { field: 'home_loc_location_name', title: 'Home Location Name' },
+  { field: 'home_loc_region', title: 'Home Region' },
+  { field: 'home_loc_fire_centre', title: 'Home Fire Centre' },
+  { field: 'home_loc_fire_zone', title: 'Home Fire Zone' },
+  { field: 'work_loc_id', title: 'Work Location ID (Internal Use)' },
+  { field: 'work_loc_location_name', title: 'Work Location Name' },
+  { field: 'work_loc_region', title: 'Work Region' },
+  { field: 'work_loc_fire_centre', title: 'Work Fire Centre' },
+  { field: 'work_loc_fire_zone', title: 'Work Fire Zone' },
+  { field: 'recommitment_personnel', title: 'Recommitment - Personnel ID' },
+  { field: 'recommitment_year', title: 'Recommitment Year' },
+  { field: 'recommitment_program', title: 'Recommitment Program' },
+  { field: 'recommitment_status', title: 'Recommitment Status' },
+  {
+    field: 'recommitment_member_decision_date',
+    title: 'Member Recommitment Decision Date',
+  },
+  { field: 'recommitment_member_reason', title: 'Member Recommitment Reason' },
+  { field: 'recommitment_supervisor_idir', title: 'Supervisor IDIR' },
+  {
+    field: 'recommitment_supervisor_decision_date',
+    title: 'Supervisor Recommitment Decision Date',
+  },
+  {
+    field: 'recommitment_supervisor_reason',
+    title: 'Supervisor Recommitment Reason',
+  },
+  {
+    field: 'recommitmentCycle_year',
+    title: 'Recommitment Cycle Year (Internal Use)',
+  },
+  {
+    field: 'recommitmentCycle_start_date',
+    title: 'Recommitment Cycle Start Date',
+  },
+  { field: 'recommitmentCycle_end_date', title: 'Recommitment Cycle End Date' },
+  {
+    field: 'recommitmentCycle_reinitiation_end_date',
+    title: 'Recommitment Cycle Reinitiation End Date',
+  },
+];

--- a/backend/src/common/enums/emcr/csv-headers.ts
+++ b/backend/src/common/enums/emcr/csv-headers.ts
@@ -6,7 +6,9 @@ using preassigned key-value pairings
 Any future adjustments to the CSV output data will require adding the appropriate
 header replacements to this const (with getRawMany(), all field names are generated
 based on their respective DB table/column (or TypeORM alias) name regardless of joins;
-for instance, personnel.first_name becomes 'personnel_first_name')
+for instance, personnel.first_name becomes 'personnel_first_name').  Note also that
+any additional columns added to existing tables also need to be accounted for here
+due to the way TypeORM handles joins
 
 Columns labelled "Internal Use" are linking PKs and the like, they don't have much
 reporting value but TypeORM's select logic makes excluding them prohibitively difficult
@@ -109,6 +111,34 @@ export const EmcrCsvHeaders = [
     title: 'Availability Confirmed On',
   },
   {
+    field: 'personnel_chips_last_ping',
+    title: 'CHIPS - Last Ping',
+  },
+  {
+    field: 'personnel_chips_last_action_date',
+    title: 'CHIPS - Last Action Date',
+  },
+  {
+    field: 'personnel_chips_profile_missing',
+    title: 'CHIPS - Profile Missing',
+  },
+  {
+    field: 'personnel_chips_last_updated_properties',
+    title: 'CHIPS - Last Updated Properties',
+  },
+  {
+    field: 'personnel_chips_issues',
+    title: 'CHIPS - Issues',
+  },
+  {
+    field: 'personnel_chips_ignore_properties',
+    title: 'CHIPS - Ignore Properties',
+  },
+  {
+    field: 'personnel_chips_training_data',
+    title: 'CHIPS - Training Data',
+  },
+  {
     field: 'personnel_work_location',
     title: 'Work Location ID (Internal Use)',
   },
@@ -157,4 +187,5 @@ export const EmcrCsvHeaders = [
     field: 'recommitmentCycle_reinitiation_end_date',
     title: 'Recommitment Cycle Reinitiation End Date',
   },
+  { field: 'last_deployed', title: 'Last Deployed Date' },
 ];

--- a/backend/src/common/enums/emcr/csv-headers.ts
+++ b/backend/src/common/enums/emcr/csv-headers.ts
@@ -9,17 +9,9 @@ based on their respective DB table/column (or TypeORM alias) name regardless of 
 for instance, personnel.first_name becomes 'personnel_first_name').  Note also that
 any additional columns added to existing tables also need to be accounted for here
 due to the way TypeORM handles joins
-
-Columns labelled "Internal Use" are linking PKs and the like, they don't have much
-reporting value but TypeORM's select logic makes excluding them prohibitively difficult
-so they're labelled for convenient removal for future reporting purposes
 */
 
 export const EmcrCsvHeaders = [
-  {
-    field: 'emcr_personnel_personnel_id',
-    title: 'EMCR Personnel ID (Internal Use)',
-  },
   { field: 'emcr_personnel_date_approved', title: 'Date Approved' },
   { field: 'emcr_personnel_date_applied', title: 'Date Applied' },
   {
@@ -44,19 +36,9 @@ export const EmcrCsvHeaders = [
   },
   { field: 'emcr_personnel_logistics_notes', title: 'EMCR Logistics Notes' },
   { field: 'emcr_personnel_status', title: 'Status' },
-  { field: 'emcr_personnel_first_aid_level', title: 'First Aid Level' },
-  { field: 'emcr_personnel_first_aid_expiry', title: 'First Aid Expiry Date' },
   {
-    field: 'emcr_personnel_psychological_first_aid',
-    title: 'Psychological First Aid',
-  },
-  {
-    field: 'emcr_personnel_first_nation_exp_living',
-    title: 'First Nations - Living Experience',
-  },
-  {
-    field: 'emcr_personnel_first_nation_exp_working',
-    title: 'First Nations - Working Experience',
+    field: 'emcr_personnel_first_nation_exp',
+    title: 'First Nations Experience',
   },
   { field: 'emcr_personnel_travel_preference', title: 'Travel Preference' },
   {
@@ -67,7 +49,6 @@ export const EmcrCsvHeaders = [
   { field: 'emcr_personnel_preoc_exp', title: 'PREOC Experience' },
   { field: 'personnel_created_at', title: 'Date Created' },
   { field: 'personnel_updated_at', title: 'Date Updated' },
-  { field: 'personnel_id', title: 'General Personnel ID (Internal Use)' },
   { field: 'personnel_first_name', title: 'First Name' },
   { field: 'personnel_last_name', title: 'Last Name' },
   { field: 'personnel_primary_phone', title: 'Primary Phone' },
@@ -138,20 +119,10 @@ export const EmcrCsvHeaders = [
     field: 'personnel_chips_training_data',
     title: 'CHIPS - Training Data',
   },
-  {
-    field: 'personnel_work_location',
-    title: 'Work Location ID (Internal Use)',
-  },
-  {
-    field: 'personnel_home_location',
-    title: 'Home Location ID (Internal Use)',
-  },
-  { field: 'home_loc_id', title: 'Home Location ID (Internal Use)' },
   { field: 'home_loc_location_name', title: 'Home Location Name' },
   { field: 'home_loc_region', title: 'Home Region' },
   { field: 'home_loc_fire_centre', title: 'Home Fire Centre' },
   { field: 'home_loc_fire_zone', title: 'Home Fire Zone' },
-  { field: 'work_loc_id', title: 'Work Location ID (Internal Use)' },
   { field: 'work_loc_location_name', title: 'Work Location Name' },
   { field: 'work_loc_region', title: 'Work Region' },
   { field: 'work_loc_fire_centre', title: 'Work Fire Centre' },
@@ -173,10 +144,6 @@ export const EmcrCsvHeaders = [
   {
     field: 'recommitment_supervisor_reason',
     title: 'Supervisor Recommitment Reason',
-  },
-  {
-    field: 'recommitmentCycle_year',
-    title: 'Recommitment Cycle Year (Internal Use)',
   },
   {
     field: 'recommitmentCycle_start_date',

--- a/backend/src/common/enums/emcr/index.ts
+++ b/backend/src/common/enums/emcr/index.ts
@@ -2,3 +2,4 @@ export * from './experience.enum';
 export * from './first-aid.enum';
 export * from './function.enum';
 export * from './region.enum';
+export * from './csv-headers';

--- a/backend/src/emcr/emcr.controller.ts
+++ b/backend/src/emcr/emcr.controller.ts
@@ -27,7 +27,7 @@ import { EmcrRO } from './ro';
 import { Program, RequestWithRoles, Role } from '../auth/interface';
 import { Programs } from '../auth/program.decorator';
 import { Public } from '../auth/public.decorator';
-import { EmcrCsvHeaders } from '../common/enums';
+//import { EmcrCsvHeaders } from '../common/enums';
 import { PersonnelEntity } from '../database/entities/personnel/personnel.entity';
 import { AppLogger } from '../logger/logger.service';
 import { GetPersonnelRO, UpdatePersonnelDTO } from '../personnel';
@@ -95,7 +95,7 @@ export class EmcrController {
 
     //convert input data to CSV format and prettify headers
     const csvConverted = json2csv(csvRawData, {
-      keys: EmcrCsvHeaders,
+      //  keys: EmcrCsvHeaders,
       useLocaleFormat: true,
     });
 

--- a/backend/src/emcr/emcr.controller.ts
+++ b/backend/src/emcr/emcr.controller.ts
@@ -27,7 +27,7 @@ import { EmcrRO } from './ro';
 import { Program, RequestWithRoles, Role } from '../auth/interface';
 import { Programs } from '../auth/program.decorator';
 import { Public } from '../auth/public.decorator';
-//import { EmcrCsvHeaders } from '../common/enums';
+import { EmcrCsvHeaders } from '../common/enums';
 import { PersonnelEntity } from '../database/entities/personnel/personnel.entity';
 import { AppLogger } from '../logger/logger.service';
 import { GetPersonnelRO, UpdatePersonnelDTO } from '../personnel';
@@ -95,7 +95,7 @@ export class EmcrController {
 
     //convert input data to CSV format and prettify headers
     const csvConverted = json2csv(csvRawData, {
-      //  keys: EmcrCsvHeaders,
+      keys: EmcrCsvHeaders,
       useLocaleFormat: true,
     });
 

--- a/backend/src/emcr/emcr.service.ts
+++ b/backend/src/emcr/emcr.service.ts
@@ -237,11 +237,12 @@ export class EmcrService {
    * Get EMCR Personnel for CSV Export
    * Extracts full raw JSON list of all EMCR-flagged personnel
    * and associated table columns for export to CSV file
-   * @returns {EmcrPersonnelEntity[]} List of personnel, converted to JSON string
+   * @returns {Entity[]} Merged TypeORM list of personnel, converted to JSON string
    */
   async getEmcrPersonnelforCSV(): Promise<EmcrPersonnelEntity[]> {
     const qb =
       this.emcrPersonnelRepository.createQueryBuilder('emcr_personnel');
+    //join with personnel table and append last deployed date as subselection
     qb.leftJoinAndSelect('emcr_personnel.personnel', 'personnel').addSelect(
       (subQuery) => {
         return subQuery

--- a/backend/src/emcr/emcr.service.ts
+++ b/backend/src/emcr/emcr.service.ts
@@ -231,6 +231,27 @@ export class EmcrService {
     });
     return { personnel, count };
   }
+
+  /**
+   * Get EMCR Personnel for CSV Export
+   * Extracts full raw JSON list of all EMCR-flagged personnel
+   * and associated table columns for export to CSV file
+   * @returns {EmcrPersonnelEntity[]} List of personnel
+   */
+  async getEmcrPersonnelforCSV(): Promise<EmcrPersonnelEntity[]> {
+    const qb =
+      this.emcrPersonnelRepository.createQueryBuilder('emcr_personnel');
+    qb.leftJoinAndSelect('emcr_personnel.personnel', 'personnel');
+    qb.leftJoinAndSelect('personnel.homeLocation', 'home_loc');
+    qb.leftJoinAndSelect('personnel.workLocation', 'work_loc');
+    qb.leftJoinAndSelect('personnel.recommitment', 'recommitment');
+    qb.leftJoinAndSelect('recommitment.recommitmentCycle', 'recommitmentCycle');
+
+    const personnel = await qb.getRawMany();
+
+    return personnel;
+  }
+
   /**
    * Get Personnel By ID
    * Returns a default availability range of 31 days for a single personnel

--- a/frontend/src/hooks/useExportToCSV.tsx
+++ b/frontend/src/hooks/useExportToCSV.tsx
@@ -1,20 +1,17 @@
+import { Program } from '@/common';
 import { useAxios } from './useAxios';
 
 export const useExportToCSV = () => {
     const { AxiosPrivate } = useAxios();
 
-    const bcwsExport = async () => {
-        const csvData = (await AxiosPrivate.get('/bcws/export-test')).data;
-        return csvData;
-    }
-
-    const emcrExport = async () => {
-        const csvData = (await AxiosPrivate.get('/emcr/export-test')).data;
+    const csvExport = async (program: Program | undefined) => {
+        const exportEndpoint = 'export-test';
+        const progPath = program?.toString();
+        const csvData = (await AxiosPrivate.get(`/${progPath}/${exportEndpoint}`)).data;
         return csvData;
     }
 
     return {
-        bcwsExport,
-        emcrExport,
+        csvExport,
     };
 };

--- a/frontend/src/hooks/useExportToCSV.tsx
+++ b/frontend/src/hooks/useExportToCSV.tsx
@@ -1,0 +1,20 @@
+import { useAxios } from './useAxios';
+
+export const useExportToCSV = () => {
+    const { AxiosPrivate } = useAxios();
+
+    const bcwsExport = async () => {
+        const csvData = (await AxiosPrivate.get('/bcws/export-test')).data;
+        return csvData;
+    }
+
+    const emcrExport = async () => {
+        const csvData = (await AxiosPrivate.get('/emcr/export-test')).data;
+        return csvData;
+    }
+
+    return {
+        bcwsExport,
+        emcrExport,
+    };
+};

--- a/frontend/src/pages/dashboard/Dashboard.tsx
+++ b/frontend/src/pages/dashboard/Dashboard.tsx
@@ -7,7 +7,7 @@ import { useRoleContext } from '@/providers';
 import { useTable } from '@/hooks';
 
 // common
-import { Filters, Role } from '@/common';
+import { Filters, Role, Program } from '@/common';
 import { Status } from '@/common';
 import { ActiveRecommitmentStatusFilter, InactiveRecommitmentStatusFilter  } from '@/common/enums/recommitment-status';
 
@@ -27,11 +27,13 @@ import { button as buttonClass } from '@/components/ui/classes';
 
 // icons
 import { QuestionMarkCircleIcon } from '@heroicons/react/24/solid';
+import { useExportToCSV } from '@/hooks/useExportToCSV';
 
 const Dashboard = () => {
   const { recommitmentCycle, isRecommitmentCycleOpen } = useRecommitmentCycle();
   const [showDescriptionsModal, setShowDescriptionsModal] = useState(false);
   const { program, roles } = useRoleContext();
+  const { emcrExport, bcwsExport } = useExportToCSV();
 
   const {
     totalRows,
@@ -83,6 +85,39 @@ const Dashboard = () => {
                     !loading && setLoading(true);
                   }}
                 />
+              )}
+              {roles && roles.includes(Role.COORDINATOR) && (
+                <button
+                  onClick={async () => {if (program === Program.BCWS) {
+                        const csvReceipt = await bcwsExport();
+                        const url = window.URL.createObjectURL(new Blob([csvReceipt]));
+                        const link = document.createElement('a');
+                        link.href = url;
+                        link.setAttribute('download', "BCWS_Personnel_Details.csv");
+                        document.body.appendChild(link);
+                        link.click();
+                        link.remove();
+                        
+                    } else {if (program === Program.EMCR) {
+                      const csvReceipt = await emcrExport();
+                        const url = window.URL.createObjectURL(new Blob([csvReceipt]));
+                        const link = document.createElement('a');
+                        link.href = url;
+                        link.setAttribute('download', "EMCR_Personnel_Details.csv");
+                        document.body.appendChild(link);
+                        link.click();
+                        link.remove();
+                      } 
+                    }
+                  }
+                }  
+                  className={buttonClass.tertiaryButton}
+                >
+                  <span className="flex flex-row items-center justify-center space-x-2 font-bold">
+                    {' '}
+                    <p className="font-bold text-white">Download All Members</p>
+                  </span>
+                </button>
               )}
               {roles && roles.includes(Role.COORDINATOR) && (
                 <button


### PR DESCRIPTION
Implements functionality for exporting of ECMR and BCWS personnel information as CSV-formatted downloadable files.  This process involves the following adjustments:

1. Addition of new methods to EMCR and BCWS services which query their respective TypeORM entities and join detailed personnel, location and recommitment information from their respective database tables.

2. Addition of new methods to EMCR and BCWS controllers which receive these service methods, convert the output to CSV format using the NPM library json-2-csv, and return streamable file versions of these outputs for download.

3. To make column headers more readable, new "enumerations" (technically consts) have been added to the enums folders for EMCR and BCWS which are used in the controller methods to rename the internal DB names for the column headers to human-readable versions.