### PR TITLE
[TC-1052] fix: rename Advance Planning Unit

### DIFF
--- a/backend/src/common/enums/emcr/function.enum.ts
+++ b/backend/src/common/enums/emcr/function.enum.ts
@@ -20,7 +20,7 @@ export enum FunctionName {
   LIAISON = 'Liaison',
   LOGISTICS = 'Logistics',
   PLANNING = 'Planning',
-  ADVANCED_PLANNING_UNIT = 'Advanced Planning Unit',
+  ADVANCED_PLANNING_UNIT = 'Advance Planning Unit',
   RECOVERY = 'Recovery',
   DEPUTY_DIRECTOR = 'Director',
   RESPONSE_INFORMATION = 'Response Information',

--- a/backend/src/common/enums/function.enum.ts
+++ b/backend/src/common/enums/function.enum.ts
@@ -20,7 +20,7 @@ export enum FunctionName {
   LIAISON = 'Liaison',
   LOGISTICS = 'Logistics',
   PLANNING = 'Planning',
-  ADVANCED_PLANNING_UNIT = 'Advanced Planning Unit',
+  ADVANCED_PLANNING_UNIT = 'Advance Planning Unit',
   RECOVERY = 'Recovery',
   DEPUTY_DIRECTOR = 'Director',
   RESPONSE_INFORMATION = 'Response Information',

--- a/backend/src/database/data.ts
+++ b/backend/src/database/data.ts
@@ -149,7 +149,7 @@ export const personnel: CreatePersonnelDTO[] = [
         {
           function: {
             id: 8,
-            name: 'Advanced Planning Unit',
+            name: 'Advance Planning Unit',
             abbreviation: 'APU',
           } as EmcrFunctionEntity,
           experienceType: Experience['INTERESTED'],
@@ -248,7 +248,7 @@ export const personnel: CreatePersonnelDTO[] = [
         {
           function: {
             id: 8,
-            name: 'Advanced Planning Unit',
+            name: 'Advance Planning Unit',
             abbreviation: 'APU',
           } as EmcrFunctionEntity,
           experienceType: Experience['OUTSIDE_EXPERIENCED'],

--- a/backend/src/database/queries.ts
+++ b/backend/src/database/queries.ts
@@ -15,7 +15,7 @@ export const functionSql = `INSERT INTO public."emcr_function" (name,abbreviatio
 	 ('Liaison','Liaison'),
 	 ('Logistics','Logs'),
 	 ('Planning','Plans'),
-	 ('Advanced Planning Unit','APU'),
+	 ('Advance Planning Unit','APU'),
 	 ('Recovery','Recovery'),
 	 ('Deputy Director','DDir'),
 	 ('Response Information', 'Response');`;

--- a/frontend/src/common/enums/function.enum.ts
+++ b/frontend/src/common/enums/function.enum.ts
@@ -6,7 +6,7 @@ export enum FunctionName {
   LIAISON = 'Liaison',
   LOGISTICS = 'Logistics',
   PLANS = 'Plans',
-  ADVANCED_PLANNING_UNIT = 'Advanced Planning Unit',
+  ADVANCED_PLANNING_UNIT = 'Advance Planning Unit',
   RECOVERY = 'Recovery',
   DIRECTOR = 'Director',
   GIS = 'GIS',

--- a/frontend/src/components/profile/sections-roles/roles.ts
+++ b/frontend/src/components/profile/sections-roles/roles.ts
@@ -1,8 +1,8 @@
 export const emcr = [
   {
-    title: 'Advanced Planning Unit',
+    title: 'Advance Planning Unit',
     description:
-      'Responsible for analyzing beyond operational period to identify potential consequences or issues. Advanced Planning is a function within the Planning section.',
+      'Responsible for analyzing beyond operational period to identify potential consequences or issues. Advance Planning is a function within the Planning section.',
   },
   {
     title: 'Deputy Director',
@@ -99,7 +99,7 @@ export const bcws = [
       {
         title: 'Plans Section Chief',
         description:
-          'Overseeing the Planning Section of the Incident. This can include: Advanced Planning, Resource Prioritization,Supervision of the Incident Action Plan, Identification of Specialized Resources, Fire Analysis, Fire Behaviour, etc.',
+          'Overseeing the Planning Section of the Incident. This can include: Advance Planning, Resource Prioritization,Supervision of the Incident Action Plan, Identification of Specialized Resources, Fire Analysis, Fire Behaviour, etc.',
       },
 
       {
@@ -432,7 +432,7 @@ export const bcws = [
       {
         title: 'Planning Officer',
         description:
-          'Overseeing the Planning Section of the Fire Centre. This can include: Advanced Planning, Fire Behaviour, Fire Analysis, Fire Centre Preparedness Planning, Rehabilitation Initiation, etc.',
+          'Overseeing the Planning Section of the Fire Centre. This can include: Advance Planning, Fire Behaviour, Fire Analysis, Fire Centre Preparedness Planning, Rehabilitation Initiation, etc.',
       },
 
       {


### PR DESCRIPTION
Description:
Renamed every instance (except for enum names) of `Advanced Planning Unit` to `Advance Planning Unit`

Note:
Might need to re-seed the DB because the insert query in `queries.ts` was changed from `AdvanceD Planning Unit`.