### PR TITLE
[TC-1102] fix: hide tooltip if not recommitmentCycle

### DIFF
--- a/frontend/src/components/toggle/Toggle.tsx
+++ b/frontend/src/components/toggle/Toggle.tsx
@@ -2,6 +2,7 @@ import { Switch } from '@headlessui/react';
 
 import { Fragment } from 'react';
 import { Tooltip } from '../ui';
+import { useRecommitmentCycle } from '@/hooks/useRecommitment';
 
 export const Toggle = ({
   value,
@@ -14,38 +15,50 @@ export const Toggle = ({
   label?: string;
   disabled?: boolean;
 }) => {
-  return (
-    
-      <>
-      {label && <p className="label px-4">{label}</p>}
-      <Tooltip content="During the recommitment period no member status may be changed"  placement={'bottom-right'}>
-      <Switch
-        checked={value}
-        onChange={handleToggle}
-        name={'showInactive'}
-        defaultChecked={false}
-        as={Fragment}
-        disabled={disabled}
-      >
-        {({ checked }) => (
-          <button
-            id={label}
-            aria-label="toggle switch"
-            className={`${
-              !checked || disabled ?  'bg-gray-200':'bg-backgroundBlue'
-            } relative inline-flex h-6 w-11 items-center rounded-full`}
-          >
-            <span className="sr-only">{'showInactive'}</span>
-            <span
-              className={`${
-                checked ? 'translate-x-6' : 'translate-x-1'
-              } inline-block h-4 w-4 transform rounded-full bg-white transition`}
-            />
-          </button>
-        )}
-      </Switch>
-      </Tooltip>
-      </>
+  const { isRecommitmentCycleOpen } = useRecommitmentCycle();
 
+  const switchComponent = (
+    <Switch
+      checked={value}
+      onChange={handleToggle}
+      name={'showInactive'}
+      defaultChecked={false}
+      as={Fragment}
+      disabled={disabled}
+    >
+      {({ checked }) => (
+        <button
+          id={label}
+          aria-label="toggle switch"
+          className={`${
+            !checked || disabled ? 'bg-gray-200' : 'bg-backgroundBlue'
+          } relative inline-flex h-6 w-11 items-center rounded-full`}
+        >
+          <span className="sr-only">{'showInactive'}</span>
+          <span
+            className={`${
+              checked ? 'translate-x-6' : 'translate-x-1'
+            } inline-block h-4 w-4 transform rounded-full bg-white transition`}
+          />
+        </button>
+      )}
+    </Switch>
+  );
+
+  const toggleComponent = isRecommitmentCycleOpen ? (
+    <Tooltip
+      content="During the recommitment period no member status may be changed"
+      placement={'bottom-right'}
+    >
+      {switchComponent}
+    </Tooltip>
+  ) : (
+    switchComponent
+  );
+  return (
+    <>
+      {label && <p className="label px-4">{label}</p>}
+      {toggleComponent}
+    </>
   );
 };


### PR DESCRIPTION
Description:
- Added a check to hide the tooltip when the recommitment cycle is inactive

Screenshots:
1) Cycle is active:
![image](https://github.com/user-attachments/assets/b405cd9e-8899-4e19-9274-6bd3b8937bc0)

2) Cycle is inactive:
![image](https://github.com/user-attachments/assets/b0553bed-3edc-4ee0-a16a-6853c6a5fc72)
