### PR TITLE
[TC-1158] fix: link wording

### DIFF
--- a/backend/src/views/intake/confirmation.njk
+++ b/backend/src/views/intake/confirmation.njk
@@ -32,15 +32,14 @@
 </ul>
 
 <p>
-  <span>BCWS CORE Team program stream</span> (submit proof of
-  completion to your Fire Centre’s email.
+  <span>BCWS CORE Team program stream</span> (submit proof of completion to your Fire Centre’s email address - see “Key Contacts” at the bottom right of the 
   <a
     href="https://intranet.gov.bc.ca/bcws/core-team"
     target="_blank"
     class="text-link"
     rel="noreferrer"
-    >Find my Fire Centre)</a
-  >
+    >BCWS Home page</a
+  >)
 </p>
 
 <ul>


### PR DESCRIPTION
Description: changed the wording to the following
![image](https://github.com/user-attachments/assets/41ef1bb2-1652-4301-8adb-6c3f54769932)
