### PR TITLE
[TC-1200] adjustment to availability query

### DIFF
--- a/backend/src/database/datasource.ts
+++ b/backend/src/database/datasource.ts
@@ -8,8 +8,6 @@ export const config = {
   username: process.env.DB_USER ?? 'tc_user',
   password: process.env.DB_PASSWORD ?? 'tc_password',
   database: process.env.DB_NAME ?? 'tc',
-  logging: true,
-  maxQueryExecutionTime: 2000,
   // TODO change this to false in production
   synchronize: process.env.ENV === 'ci',
   entities: [join(__dirname, '**', '*.entity.{ts,js}')],

--- a/backend/src/personnel/personnel.service.ts
+++ b/backend/src/personnel/personnel.service.ts
@@ -533,7 +533,7 @@ export class PersonnelService {
       const end = parse(availabilityToDate, 'yyyy-MM-dd', new Date());
 
       this.logger.log(`Availability From Date: ${start}`);
-      this.logger.log(`Availability From Date: ${end}`);
+      this.logger.log(`Availability To Date: ${end}`);
       this.logger.log(
         `Difference In Days: ${differenceInDays(
           availabilityToDate,
@@ -565,7 +565,7 @@ export class PersonnelService {
             `personnel.id not IN (${allAvailable.getQuery()})`,
             allAvailable.getParameters(),
           )
-          .andWhere('personnel.availability_confirmed_until > :date', {
+          .andWhere('personnel.availability_confirmed_until >= :date', {
             date: end,
           });
 

--- a/backend/src/personnel/personnel.service.ts
+++ b/backend/src/personnel/personnel.service.ts
@@ -566,7 +566,7 @@ export class PersonnelService {
             allAvailable.getParameters(),
           )
           .andWhere('personnel.availability_confirmed_until >= :date', {
-            date: end,
+            date: start,
           });
 
         queryBuilder.leftJoinAndSelect(

--- a/frontend/src/components/table/classes.ts
+++ b/frontend/src/components/table/classes.ts
@@ -9,6 +9,8 @@ export const tableClass = {
 
 export const getUnionMembershipClass = (value?: string) => {
   switch (value) {
+    case UnionMembership.OTHER:
+      return `${tableClass.classificationClass} text-warning bg-warningBannerLight border-warningDark`;
     case UnionMembership.BCGEU:
       return `${tableClass.classificationClass} text-info bg-infoBannerLight border-infoDark`;
     case UnionMembership.EXCLUDED:


### PR DESCRIPTION
[TC-1200](https://bcdevex.atlassian.net/browse/TC-1200)

Objective:

Currently if you are searching for a member by an available date range, the member will only show up if the confirmed until date is after the the [query.to](http://query.to/) date. We allow partial matches so this should be changed to include users whose confirmed until date is greater than or equal to the query.from date.